### PR TITLE
Add APIs for deleteConfig and getAllConfigs and modify semantics of upsertConfig

### DIFF
--- a/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
+++ b/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
@@ -87,7 +87,7 @@ message DeleteConfigRequest {
   // required - namespace with which the config resource is associated
   string resource_namespace = 2;
 
-  // required - for default context, use "DEFAULT-CONTEXT"
+  // required
   string context = 3;
 }
 

--- a/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
+++ b/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
@@ -31,7 +31,8 @@ message UpsertConfigRequest {
   // required - config value to be upserted
   google.protobuf.Value config = 3;
 
-  // optional - only required if config applies to a specific context
+  // optional - only required if config applies to a specific context.
+  // If empty, specified config is associated with a default context.
   string context = 4;
 }
 

--- a/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
+++ b/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
@@ -7,27 +7,89 @@ package org.hypertrace.config.service.v1;
 import "google/protobuf/struct.proto";
 
 service ConfigService {
+  // Merges the specified config with the existing config and upserts the
+  // resulting config into the store. Also returns the config which is upserted.
   rpc UpsertConfig(UpsertConfigRequest) returns (UpsertConfigResponse) {}
+
+  // Gets the config for the specified request
   rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
+
+  // Gets all the configs(i.e. across all the contexts) for the specified request
+  rpc GetAllConfigs(GetAllConfigsRequest) returns (GetAllConfigsResponse) {}
+
+  // Deletes the config for the specified request
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse) {}
 }
 
 message UpsertConfigRequest {
-  string resource_name = 1;  // required
-  string resource_namespace = 2;  // required - namespace with which the config resource is associated
-  google.protobuf.Value config = 3; // required - config value to be upserted
-  string context = 4; // optional - only required if config applies to a specific context
+  // required - name of the resource associated with the config
+  string resource_name = 1;
+
+  // required - namespace with which the config resource is associated
+  string resource_namespace = 2;
+
+  // required - config value to be upserted
+  google.protobuf.Value config = 3;
+
+  // optional - only required if config applies to a specific context
+  string context = 4;
 }
 
 message UpsertConfigResponse {
-  int64 config_version = 1; // the version allocated to the newly inserted configuration
+  // config value upserted into the store
+  google.protobuf.Value config = 1;
 }
 
 message GetConfigRequest {
-  string resource_name = 1;  // required
-  string resource_namespace = 2;  // required - namespace with which the config resource is associated
-  repeated string contexts = 3; // optional; order matters - specify the contexts in the order of increasing priority. Example: ["service1", "api1"]
+  // required - name of the resource associated with the config
+  string resource_name = 1;
+
+  // required - namespace with which the config resource is associated
+  string resource_namespace = 2;
+
+  // optional; order matters - specify the contexts in the order of increasing
+  // priority. Example: ["service1", "api1"].
+  // Default context is implicitly appended to the beginning of the list.
+  repeated string contexts = 3;
 }
 
 message GetConfigResponse {
+  // config value returned for the specified request
   google.protobuf.Value config = 1;
+}
+
+message GetAllConfigsRequest {
+  // required - name of the resource associated with the config
+  string resource_name = 1;
+
+  // required - namespace with which the config resource is associated
+  string resource_namespace = 2;
+}
+
+message GetAllConfigsResponse {
+  // list of config values along with the associated contexts
+  repeated ContextSpecificConfig context_specific_configs = 1;
+}
+
+message ContextSpecificConfig {
+  // context associated with the below config
+  string context = 1;
+
+  // config value which applies to the above context
+  google.protobuf.Value config = 2;
+}
+
+message DeleteConfigRequest {
+  // required - name of the resource associated with the config
+  string resource_name = 1;
+
+  // required - namespace with which the config resource is associated
+  string resource_namespace = 2;
+
+  // required - for default context, use "DEFAULT-CONTEXT"
+  string context = 3;
+}
+
+// empty response
+message DeleteConfigResponse {
 }

--- a/config-service-impl/build.gradle.kts
+++ b/config-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":config-service-api"))
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.10.0")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.10.5.1")
   implementation("com.google.guava:guava:30.0-jre")
   implementation("com.google.protobuf:protobuf-java-util:3.13.0")
   implementation("com.typesafe:config:1.4.0")

--- a/config-service-impl/build.gradle.kts
+++ b/config-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":config-service-api"))
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.9.10.7")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.10.0")
   implementation("com.google.guava:guava:30.0-jre")
   implementation("com.google.protobuf:protobuf-java-util:3.13.0")
   implementation("com.typesafe:config:1.4.0")

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceUtils.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceUtils.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ConfigServiceUtils {
 
   public static final String DEFAULT_CONTEXT = "DEFAULT-CONTEXT";
+  private static final Value EMPTY_VALUE = Value.newBuilder().setNullValue(NullValue.NULL_VALUE)
+      .build();
 
   private ConfigServiceUtils() {
     // to prevent instantiation
@@ -23,6 +25,7 @@ public class ConfigServiceUtils {
   /**
    * Deep merge the specified {@link Value} configs with overridingConfig taking precedence over
    * defaultConfig for the same keys.
+   *
    * @param defaultConfig
    * @param overridingConfig
    * @return the resulting config obtained after merging defaultConfig and overridingConfig
@@ -54,8 +57,9 @@ public class ConfigServiceUtils {
   }
 
   /**
-   * Get the actual context from rawContext. Specifically, it handles the case where rawContext
-   * can be null or empty which is equivalent to default context.
+   * Get the actual context from rawContext. Specifically, it handles the case where rawContext can
+   * be null or empty which is equivalent to default context.
+   *
    * @param rawContext
    * @return
    */
@@ -63,7 +67,7 @@ public class ConfigServiceUtils {
     return Strings.isNullOrEmpty(rawContext) ? DEFAULT_CONTEXT : rawContext;
   }
 
-  private static boolean isNull(Value value) {
+  public static boolean isNull(Value value) {
     if (value == null) {
       log.error("NULL Value encountered. This is unexpected and indicates a BUG in code.",
           new RuntimeException());
@@ -74,10 +78,14 @@ public class ConfigServiceUtils {
 
   public static Value nullSafeValue(Value value) {
     if (value == null) {
-      log.error("NULL Value encountered. This is unexpected and indicates a BUG in code.", 
+      log.error("NULL Value encountered. This is unexpected and indicates a BUG in code.",
           new RuntimeException());
-      return Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+      return emptyValue();
     }
     return value;
+  }
+
+  public static Value emptyValue() {
+    return EMPTY_VALUE;
   }
 }

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigStore.java
@@ -2,9 +2,11 @@ package org.hypertrace.config.service.store;
 
 import com.google.protobuf.Value;
 import com.typesafe.config.Config;
+import java.util.List;
 import org.hypertrace.config.service.ConfigResource;
 
 import java.io.IOException;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
 
 /**
  * Abstraction for the backend which stores and serves the configuration data for multiple
@@ -27,8 +29,7 @@ public interface ConfigStore {
    * @param config
    * @return the version allocated to the newly inserted configuration
    */
-  long writeConfig(ConfigResource configResource, String userId, Value config)
-      throws IOException;
+  long writeConfig(ConfigResource configResource, String userId, Value config) throws IOException;
 
   /**
    * Get the config with the latest version for the specified resource.
@@ -39,7 +40,21 @@ public interface ConfigStore {
   Value getConfig(ConfigResource configResource) throws IOException;
 
   /**
+   * Get all the configs with the latest version(along with the context to which it applies) for the
+   * specified parameters.
+   *
+   * @param resourceName
+   * @param resourceNamespace
+   * @param tenantId
+   * @return
+   * @throws IOException
+   */
+  List<ContextSpecificConfig> getAllConfigs(String resourceName, String resourceNamespace,
+      String tenantId) throws IOException;
+
+  /**
    * Health check for the backend store
+   *
    * @return
    */
   boolean healthCheck();

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceUtilsTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceUtilsTest.java
@@ -1,11 +1,12 @@
 package org.hypertrace.config.service;
 
 import static org.hypertrace.config.service.ConfigServiceUtils.DEFAULT_CONTEXT;
+import static org.hypertrace.config.service.TestUtils.getConfig1;
+import static org.hypertrace.config.service.TestUtils.getConfig2;
+import static org.hypertrace.config.service.TestUtils.getExpectedMergedConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
-import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import org.junit.jupiter.api.Test;
 
@@ -13,17 +14,16 @@ class ConfigServiceUtilsTest {
 
   @Test
   void merge() {
-    Value config1Value = getConfig1Value();
-    Value config2Value = getConfig2Value();
+    Value config1 = getConfig1();
+    Value config2 = getConfig2();
 
     // test merging 2 config values
-    assertEquals(getExpectedMergedConfigValue(),
-        ConfigServiceUtils.merge(config1Value, config2Value));
+    assertEquals(getExpectedMergedConfig(), ConfigServiceUtils.merge(config1, config2));
 
     // test merging with null value
     Value nullConfigValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-    assertEquals(config1Value, ConfigServiceUtils.merge(config1Value, nullConfigValue));
-    assertEquals(config1Value, ConfigServiceUtils.merge(nullConfigValue, config1Value));
+    assertEquals(config1, ConfigServiceUtils.merge(config1, nullConfigValue));
+    assertEquals(config1, ConfigServiceUtils.merge(nullConfigValue, config1));
   }
 
   @Test
@@ -31,65 +31,5 @@ class ConfigServiceUtilsTest {
     assertEquals(DEFAULT_CONTEXT, ConfigServiceUtils.getActualContext(null));
     assertEquals(DEFAULT_CONTEXT, ConfigServiceUtils.getActualContext(""));
     assertEquals("ctx1", ConfigServiceUtils.getActualContext("ctx1"));
-  }
-
-  /**
-   * This method returns the {@link Value} corresponding to the below JSON
-   * { "k1": 10, "k2":"v2", "k3": [ { "k31": "v31" }, { "k32": "v32" } ] }
-   */
-  private Value getConfig1Value() {
-    ListValue listValueForK3 = ListValue.newBuilder()
-        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k31", "v31")).build())
-        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k32", "v32")).build())
-        .build();
-    Struct struct = Struct.newBuilder()
-        .putFields("k1", Value.newBuilder().setNumberValue(10).build())
-        .putFields("k2", Value.newBuilder().setStringValue("v2").build())
-        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
-        .build();
-
-    return Value.newBuilder().setStructValue(struct).build();
-  }
-
-  /**
-   * This method returns the {@link Value} corresponding to the below JSON
-   * { "k1": 20, "k3":[ { "k33": "v33" } ], "k4": "v4" }
-   */
-  private Value getConfig2Value() {
-    ListValue listValueForK3 = ListValue.newBuilder()
-        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k33", "v33")).build())
-        .build();
-    Struct struct = Struct.newBuilder()
-        .putFields("k1", Value.newBuilder().setNumberValue(20).build())
-        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
-        .putFields("k4", Value.newBuilder().setStringValue("v4").build())
-        .build();
-
-    return Value.newBuilder().setStructValue(struct).build();
-  }
-
-  /**
-   * This method returns the {@link Value} corresponding to the below JSON (obtained by
-   * merging config1 and config2) 
-   * { "k1": 20, "k2": "v2", "k3": [ { "k33": "v33" } ], "k4": "v4" }
-   */
-  private Value getExpectedMergedConfigValue() {
-    ListValue listValueForK3 = ListValue.newBuilder()
-        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k33", "v33")).build())
-        .build();
-    Struct struct = Struct.newBuilder()
-        .putFields("k1", Value.newBuilder().setNumberValue(20).build())
-        .putFields("k2", Value.newBuilder().setStringValue("v2").build())
-        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
-        .putFields("k4", Value.newBuilder().setStringValue("v4").build())
-        .build();
-
-    return Value.newBuilder().setStructValue(struct).build();
-  }
-
-  private Struct getStructForKeyValue(String key, String value) {
-    return Struct.newBuilder()
-        .putFields(key, Value.newBuilder().setStringValue(value).build())
-        .build();
   }
 }

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/TestUtils.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/TestUtils.java
@@ -2,9 +2,9 @@ package org.hypertrace.config.service;
 
 import static org.hypertrace.config.service.ConfigServiceUtils.DEFAULT_CONTEXT;
 
+import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import java.util.Map;
 
 public class TestUtils {
 
@@ -21,20 +21,62 @@ public class TestUtils {
     return new ConfigResource(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_ID, context);
   }
 
-  public static Value getConfigValue() {
-    return getConfigValue(Map.of("street", "101A, Street s1",
-        "city", "city1","state", "state1"));
-  }
-
-  public static Value getConfigValue(Map<String, String> addressFields) {
-    Struct.Builder addressBuilder = Struct.newBuilder();
-    addressFields.forEach((k, v) ->
-        addressBuilder.putFields(k, Value.newBuilder().setStringValue(v).build()));
-    Value addressValue = Value.newBuilder().setStructValue(addressBuilder.build()).build();
-    Struct billingInfo = Struct.newBuilder()
-        .putFields("address", addressValue)
+  /**
+   * This method returns the {@link Value} corresponding to the below JSON { "k1": 10, "k2":"v2",
+   * "k3": [ { "k31": "v31" }, { "k32": "v32" } ] }
+   */
+  public static Value getConfig1() {
+    ListValue listValueForK3 = ListValue.newBuilder()
+        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k31", "v31")).build())
+        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k32", "v32")).build())
         .build();
-    return Value.newBuilder().setStructValue(billingInfo).build();
+    Struct struct = Struct.newBuilder()
+        .putFields("k1", Value.newBuilder().setNumberValue(10).build())
+        .putFields("k2", Value.newBuilder().setStringValue("v2").build())
+        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
+        .build();
+
+    return Value.newBuilder().setStructValue(struct).build();
   }
 
+  /**
+   * This method returns the {@link Value} corresponding to the below JSON { "k1": 20, "k3":[ {
+   * "k33": "v33" } ], "k4": "v4" }
+   */
+  public static Value getConfig2() {
+    ListValue listValueForK3 = ListValue.newBuilder()
+        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k33", "v33")).build())
+        .build();
+    Struct struct = Struct.newBuilder()
+        .putFields("k1", Value.newBuilder().setNumberValue(20).build())
+        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
+        .putFields("k4", Value.newBuilder().setStringValue("v4").build())
+        .build();
+
+    return Value.newBuilder().setStructValue(struct).build();
+  }
+
+  /**
+   * This method returns the {@link Value} corresponding to the below JSON (obtained by merging
+   * config1 and config2) { "k1": 20, "k2": "v2", "k3": [ { "k33": "v33" } ], "k4": "v4" }
+   */
+  public static Value getExpectedMergedConfig() {
+    ListValue listValueForK3 = ListValue.newBuilder()
+        .addValues(Value.newBuilder().setStructValue(getStructForKeyValue("k33", "v33")).build())
+        .build();
+    Struct struct = Struct.newBuilder()
+        .putFields("k1", Value.newBuilder().setNumberValue(20).build())
+        .putFields("k2", Value.newBuilder().setStringValue("v2").build())
+        .putFields("k3", Value.newBuilder().setListValue(listValueForK3).build())
+        .putFields("k4", Value.newBuilder().setStringValue("v4").build())
+        .build();
+
+    return Value.newBuilder().setStructValue(struct).build();
+  }
+
+  private static Struct getStructForKeyValue(String key, String value) {
+    return Struct.newBuilder()
+        .putFields(key, Value.newBuilder().setStringValue(value).build())
+        .build();
+  }
 }

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
@@ -90,6 +90,25 @@ class DocumentConfigStoreTest {
     assertEquals(config1, config);
   }
 
+  @Test
+  void getAllConfigs() throws IOException {
+    List<Document> documentList = List
+        .of(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1),
+            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION - 1, config2),
+            getConfigDocument(CONTEXT1, 1L, config2));
+    when(collection.search(any(Query.class))).thenReturn(documentList.iterator());
+
+    List<ContextSpecificConfig> contextSpecificConfigList = configStore
+        .getAllConfigs(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_ID);
+    assertEquals(2, contextSpecificConfigList.size());
+    assertEquals(
+        ContextSpecificConfig.newBuilder().setContext(DEFAULT_CONTEXT).setConfig(config1).build(),
+        contextSpecificConfigList.get(0));
+    assertEquals(
+        ContextSpecificConfig.newBuilder().setContext(CONTEXT1).setConfig(config2).build(),
+        contextSpecificConfigList.get(1));
+  }
+
   private static Document getConfigDocument(String context, long version, Value config) {
     return new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
         TENANT_ID, context, version, USER_ID, config);

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
@@ -1,20 +1,22 @@
 package org.hypertrace.config.service.store;
 
 import static org.hypertrace.config.service.ConfigServiceUtils.DEFAULT_CONTEXT;
+import static org.hypertrace.config.service.TestUtils.CONTEXT1;
 import static org.hypertrace.config.service.TestUtils.RESOURCE_NAME;
 import static org.hypertrace.config.service.TestUtils.RESOURCE_NAMESPACE;
 import static org.hypertrace.config.service.TestUtils.TENANT_ID;
+import static org.hypertrace.config.service.TestUtils.getConfig1;
+import static org.hypertrace.config.service.TestUtils.getConfig2;
 import static org.hypertrace.config.service.TestUtils.getConfigResource;
-import static org.hypertrace.config.service.TestUtils.getConfigValue;
 import static org.hypertrace.config.service.store.DocumentConfigStore.CONFIGURATIONS_COLLECTION;
 import static org.hypertrace.config.service.store.DocumentConfigStore.DATA_STORE_TYPE;
 import static org.hypertrace.config.service.store.DocumentConfigStore.DOC_STORE_CONFIG_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.protobuf.Value;
 import com.typesafe.config.Config;
@@ -24,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hypertrace.config.service.ConfigResource;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Datastore;
 import org.hypertrace.core.documentstore.DatastoreProvider;
@@ -39,16 +43,14 @@ class DocumentConfigStoreTest {
   private static final long CONFIG_VERSION = 5;
   private static final String USER_ID = "user1";
   private static DocumentConfigStore configStore = new DocumentConfigStore();
+  private static Value config1 = getConfig1();
+  private static Value config2 = getConfig2();
+  private static ConfigResource configResource = getConfigResource();
   private static Collection collection;
-  
+
   @BeforeAll
   static void init() {
     collection = mock(Collection.class);
-    doAnswer(invocation -> {
-      List<Document> documentList = Collections.singletonList(getConfigDocument(CONFIG_VERSION));
-      return documentList.iterator();
-    }).when(collection).search(any(Query.class));
-
     String datastoreType = "MockDatastore";
     DatastoreProvider.register(datastoreType, MockDatastore.class);
     Map<String, Object> dataStoreConfig = Map.of(DATA_STORE_TYPE, datastoreType,
@@ -60,29 +62,37 @@ class DocumentConfigStoreTest {
 
   @Test
   void writeConfig() throws IOException {
-    configStore.writeConfig(getConfigResource(), USER_ID, getConfigValue());
+    List<Document> documentList = Collections
+        .singletonList(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1));
+    when(collection.search(any(Query.class))).thenReturn(documentList.iterator());
+
+    configStore.writeConfig(configResource, USER_ID, config1);
 
     ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
     ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
-    verify(collection, times(1))
-        .upsert(keyCaptor.capture(), documentCaptor.capture());
+    verify(collection, times(1)).upsert(keyCaptor.capture(), documentCaptor.capture());
 
     Key key = keyCaptor.getValue();
     Document document = documentCaptor.getValue();
     long newVersion = CONFIG_VERSION + 1;
-    assertEquals(new ConfigDocumentKey(getConfigResource(), newVersion), key);
-    assertEquals(getConfigDocument(newVersion), document);
+    assertEquals(new ConfigDocumentKey(configResource, newVersion), key);
+    assertEquals(getConfigDocument(DEFAULT_CONTEXT, newVersion, config1), document);
   }
 
   @Test
   void getConfig() throws IOException {
-    Value config = configStore.getConfig(getConfigResource());
-    assertEquals(getConfigValue(), config);
+    List<Document> documentList = Collections
+        .singletonList(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1));
+    when(collection.search(any(Query.class)))
+        .thenReturn(documentList.iterator(), documentList.iterator());
+
+    Value config = configStore.getConfig(configResource);
+    assertEquals(config1, config);
   }
-  
-  private static ConfigDocument getConfigDocument(long version) {
+
+  private static Document getConfigDocument(String context, long version, Value config) {
     return new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
-        TENANT_ID, DEFAULT_CONTEXT, version, USER_ID, getConfigValue());
+        TENANT_ID, context, version, USER_ID, config);
   }
 
   public static class MockDatastore implements Datastore {

--- a/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
+++ b/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
@@ -3,13 +3,20 @@ package org.hypertrace.config.service;
 import static org.hypertrace.config.service.IntegrationTestUtils.getConfigValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.protobuf.NullValue;
 import com.google.protobuf.Value;
 import io.grpc.Channel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.hypertrace.config.service.v1.ConfigServiceGrpc;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
 import org.hypertrace.config.service.v1.GetConfigRequest;
 import org.hypertrace.config.service.v1.GetConfigResponse;
 import org.hypertrace.config.service.v1.UpsertConfigRequest;
@@ -19,6 +26,7 @@ import org.hypertrace.core.grpcutils.client.RequestContextClientCallCredsProvide
 import org.hypertrace.core.serviceframework.IntegrationTestServerUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,6 +40,7 @@ public class ConfigServiceIntegrationTest {
   private static final String TENANT_2 = "tenant2";
   private static final String CONTEXT_1 = "ctx1";
   private static final String CONTEXT_2 = "ctx2";
+  private static final String DEFAULT_CONTEXT = "DEFAULT-CONTEXT";
 
   private static ConfigServiceGrpc.ConfigServiceBlockingStub configServiceBlockingStub;
   private static Value config1;
@@ -61,29 +70,36 @@ public class ConfigServiceIntegrationTest {
     IntegrationTestServerUtil.shutdownServices();
   }
 
-  @Test
-  public void testUpsertAndGetConfig() {
-    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config1);
-
-    GetConfigResponse getConfigResponse = getConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1);
-    assertEquals(config1, getConfigResponse.getConfig());
-
-    // upsert second version of config
-    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config2);
-
-    // upsert config for second tenant
-    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2, Optional.empty(), config3);
-
-    // get config should return latest config values for respective tenant
-    getConfigResponse = getConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1);
-    assertEquals(config2, getConfigResponse.getConfig());
-
-    getConfigResponse = getConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2);
-    assertEquals(config3, getConfigResponse.getConfig());
+  @BeforeEach
+  public void clearPreviousState() {
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, DEFAULT_CONTEXT);
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2, DEFAULT_CONTEXT);
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_1);
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2, CONTEXT_1);
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_2);
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2, CONTEXT_2);
   }
 
   @Test
-  public void testUpsertAndGetConfigWithContext() {
+  public void testUpsertConfig() {
+    // upsert first version of config for tenant-1
+    UpsertConfigResponse upsertConfigResponse = upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE,
+        TENANT_1, Optional.empty(), config1);
+    assertEquals(config1, upsertConfigResponse.getConfig());
+
+    // upsert second version of config for tenant-1
+    upsertConfigResponse = upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1,
+        Optional.empty(), config2);
+    assertEquals(config3, upsertConfigResponse.getConfig());
+
+    // test across tenants - upsert first version of config for tenant-2
+    upsertConfigResponse = upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2,
+        Optional.empty(), config1);
+    assertEquals(config1, upsertConfigResponse.getConfig());
+  }
+
+  @Test
+  public void testGetConfig() {
     // upsert config with default or no context
     upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config1);
 
@@ -106,6 +122,48 @@ public class ConfigServiceIntegrationTest {
     assertEquals(config1, getContext2ConfigResponse.getConfig());
   }
 
+  @Test
+  public void testGetAllConfigs() {
+    // upsert config with default or no context
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config1);
+
+    // upsert config with context
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_1), config2);
+
+    List<ContextSpecificConfig> contextSpecificConfigList = getAllConfigs(RESOURCE_NAME,
+        RESOURCE_NAMESPACE, TENANT_1).getContextSpecificConfigsList();
+    assertEquals(2, contextSpecificConfigList.size());
+    assertEquals(
+        ContextSpecificConfig.newBuilder().setContext(DEFAULT_CONTEXT).setConfig(config1).build(),
+        contextSpecificConfigList.get(0));
+    assertEquals(
+        ContextSpecificConfig.newBuilder().setContext(CONTEXT_1).setConfig(config2).build(),
+        contextSpecificConfigList.get(1));
+  }
+
+  @Test
+  public void testDeleteConfig() {
+    // upsert config with default or no context
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config1);
+
+    // upsert config with context
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_1), config2);
+
+    // delete config with context
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_1);
+
+    // get config with context should return default config
+    Value config = getConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_1).getConfig();
+    assertEquals(config1, config);
+
+    // delete config with default context also
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, DEFAULT_CONTEXT);
+
+    // get config with context should return empty config
+    config = getConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_1).getConfig();
+    assertEquals(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build(), config);
+  }
+
   private UpsertConfigResponse upsertConfig(String resourceName, String resourceNamespace,
       String tenantId, Optional<String> context, Value config) {
     UpsertConfigRequest.Builder builder = UpsertConfigRequest.newBuilder()
@@ -115,7 +173,6 @@ public class ConfigServiceIntegrationTest {
     if (context.isPresent()) {
       builder.setContext(context.get());
     }
-
     return GrpcClientRequestContextUtil.executeInTenantContext(
         tenantId, () -> configServiceBlockingStub.upsertConfig(builder.build()));
   }
@@ -127,9 +184,29 @@ public class ConfigServiceIntegrationTest {
         .setResourceNamespace(resourceNamespace)
         .addAllContexts(Arrays.asList(contexts))
         .build();
-
     return GrpcClientRequestContextUtil.executeInTenantContext(
         tenantId, () -> configServiceBlockingStub.getConfig(getConfigRequest));
+  }
+
+  private GetAllConfigsResponse getAllConfigs(String resourceName, String resourceNamespace,
+      String tenantId) {
+    GetAllConfigsRequest request = GetAllConfigsRequest.newBuilder()
+        .setResourceName(resourceName)
+        .setResourceNamespace(resourceNamespace)
+        .build();
+    return GrpcClientRequestContextUtil.executeInTenantContext(
+        tenantId, () -> configServiceBlockingStub.getAllConfigs(request));
+  }
+
+  private DeleteConfigResponse deleteConfig(String resourceName, String resourceNamespace,
+      String tenantId, String context) {
+    DeleteConfigRequest request = DeleteConfigRequest.newBuilder()
+        .setResourceName(resourceName)
+        .setResourceNamespace(resourceNamespace)
+        .setContext(context)
+        .build();
+    return GrpcClientRequestContextUtil.executeInTenantContext(
+        tenantId, () -> configServiceBlockingStub.deleteConfig(request));
   }
 
 }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -83,9 +83,6 @@ configServiceConfig:
     host: mongo
     url: ""
 
-attributes: []
-extraAttributes: []
-
 logConfig:
   name: config-service-log-config
   monitorInterval: 30


### PR DESCRIPTION
## Description
- Add API for getting all configs (i.e. across all the contexts) for the specified request
- Add API for deleting the config for the specified request
- Update semantics of upsert config API - It should merge the specified config with the existing config and upsert the resulting config into the store. Also it should return the config which is upserted.

### Testing
Added and updated unit tests and integration tests for the changes made. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules