### PR TITLE
feat: add spaces config service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 
 .idea
+*.log

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,7 @@
 build:
   roots:
     - config-service-api/src/main/proto
+    - spaces-config-service-api/src/main/proto
 lint:
   use:
     - DEFAULT

--- a/config-proto-converter/build.gradle.kts
+++ b/config-proto-converter/build.gradle.kts
@@ -6,4 +6,9 @@ plugins {
 dependencies {
   api("io.grpc:grpc-protobuf:1.34.1")
   implementation("com.google.protobuf:protobuf-java-util:3.13.0")
+  constraints {
+    implementation("com.google.guava:guava:30.1-jre") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
+    }
+  }
 }

--- a/config-proto-converter/build.gradle.kts
+++ b/config-proto-converter/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  `java-library`
+}
+
+
+dependencies {
+  api("io.grpc:grpc-protobuf:1.34.1")
+  implementation("com.google.protobuf:protobuf-java-util:3.13.0")
+}

--- a/config-proto-converter/src/main/java/org/hypertrace/config/proto/converter/ConfigProtoConverter.java
+++ b/config-proto-converter/src/main/java/org/hypertrace/config/proto/converter/ConfigProtoConverter.java
@@ -1,0 +1,24 @@
+package org.hypertrace.config.proto.converter;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+
+public class ConfigProtoConverter {
+  private static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer();
+  private static final JsonFormat.Parser JSON_PARSER = JsonFormat.parser().ignoringUnknownFields();
+
+  public static void mergeFromValue(Value value, Message.Builder builder)
+      throws InvalidProtocolBufferException {
+    JSON_PARSER.merge(JSON_PRINTER.print(value), builder);
+  }
+
+  public static Value convertToValue(MessageOrBuilder messageOrBuilder)
+      throws InvalidProtocolBufferException {
+    Value.Builder valueBuilder = Value.newBuilder();
+    JSON_PARSER.merge(JSON_PRINTER.print(messageOrBuilder), valueBuilder);
+    return valueBuilder.build();
+  }
+}

--- a/config-service-api/build.gradle.kts
+++ b/config-service-api/build.gradle.kts
@@ -17,7 +17,7 @@ protobuf {
     // the identifier, which can be referred to in the "plugins"
     // container of the "generateProtoTasks" closure.
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.33.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.34.1"
     }
 
     if (generateLocalGoGrpcFiles) {
@@ -56,8 +56,8 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.33.1")
-  api("io.grpc:grpc-stub:1.33.1")
+  api("io.grpc:grpc-protobuf:1.34.1")
+  api("io.grpc:grpc-stub:1.34.1")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
   testFixturesImplementation("org.mockito:mockito-core:3.7.0")
 
   constraints {
-    implementation("com.google.guava:guava:30.0-jre") {
+    implementation("com.google.guava:guava:30.1-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
     }
     runtimeOnly("io.netty:netty-codec-http2:4.1.53.Final") {

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   java
   application
   jacoco
+  `java-test-fixtures`
   id("org.hypertrace.docker-java-application-plugin")
   id("org.hypertrace.docker-publish-plugin")
   id("org.hypertrace.integration-test-plugin")
@@ -55,6 +56,30 @@ tasks.integrationTest {
 
 dependencies {
   implementation(project(":config-service-impl"))
+  implementation(project(":spaces-config-service-impl"))
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.2")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
+  implementation("com.typesafe:config:1.4.0")
+  implementation("org.slf4j:slf4j-api:1.7.30")
+
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
+  runtimeOnly("io.grpc:grpc-netty:1.34.1")
+
+  //Integration test dependencies
+  integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  integrationTestImplementation("com.google.guava:guava:30.0-jre")
+  integrationTestImplementation("org.yaml:snakeyaml:1.26")
+  integrationTestImplementation(project(":config-service-impl"))
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.18")
+  integrationTestImplementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.2")
+
+  testFixturesApi("io.grpc:grpc-api:1.34.1")
+  testFixturesApi(project(":config-service-api"))
+  testFixturesImplementation(project(":config-service-impl"))
+  testFixturesImplementation("io.grpc:grpc-stub:1.34.1")
+  testFixturesImplementation("io.grpc:grpc-core:1.34.1")
+  testFixturesImplementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.2")
+  testFixturesImplementation("org.mockito:mockito-core:3.7.0")
 
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
@@ -67,23 +92,6 @@ dependencies {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
     }
   }
-
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.2")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
-
-  runtimeOnly("io.grpc:grpc-netty:1.33.1")
-  implementation("com.typesafe:config:1.4.0")
-
-  implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
-
-  //Integration test dependencies
-  integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
-  integrationTestImplementation("com.google.guava:guava:30.0-jre")
-  integrationTestImplementation("org.yaml:snakeyaml:1.26")
-  integrationTestImplementation(project(":config-service-impl"))
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.18")
-  integrationTestImplementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.2")
 }
 
 application {
@@ -91,7 +99,7 @@ application {
 }
 
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.
-tasks.run<JavaExec>  {
+tasks.run<JavaExec> {
   jvmArgs = listOf("-Dservice.name=${project.name}")
 }
 

--- a/config-service/src/main/resources/configs/config-service/application.conf
+++ b/config-service/src/main/resources/configs/config-service/application.conf
@@ -2,11 +2,14 @@ main.class = org.hypertrace.config.service.ConfigService
 service.name = config-service
 service.port = 50101
 service.admin.port = 50102
-document.store {
-  dataStoreType = mongo
-  mongo {
-    host = localhost
-    host = ${?MONGO_HOST} # provides a way to override the mongo_host via an environment variable
-    port = 27017
+
+generic.config.service {
+  document.store {
+    dataStoreType = mongo
+    mongo {
+      host = localhost
+      host = ${?MONGO_HOST} # provides a way to override the mongo_host via an environment variable
+      port = 27017
+    }
   }
 }

--- a/config-service/src/testFixtures/java/org/hypertrace/config/service/MockGenericConfigService.java
+++ b/config-service/src/testFixtures/java/org/hypertrace/config/service/MockGenericConfigService.java
@@ -39,7 +39,7 @@ import org.mockito.Mockito;
  * A mock implementation of the generic config service. Limited support right now, it assumes all
  * calls are scoped to the same resource name/namespace.
  *
- * <p>Each method must be explicitly requested for mocking to
+ * <p>Each method must be explicitly requested for mocking to allow strict stubbing.
  */
 public class MockGenericConfigService {
 

--- a/config-service/src/testFixtures/java/org/hypertrace/config/service/MockGenericConfigService.java
+++ b/config-service/src/testFixtures/java/org/hypertrace/config/service/MockGenericConfigService.java
@@ -1,0 +1,190 @@
+package org.hypertrace.config.service;
+
+import com.google.protobuf.Value;
+import io.grpc.BindableService;
+import io.grpc.Channel;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceImplBase;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.ContextSpecificConfig.Builder;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+/**
+ * A mock implementation of the generic config service. Limited support right now, it assumes all
+ * calls are scoped to the same resource name/namespace.
+ *
+ * <p>Each method must be explicitly requested for mocking to
+ */
+public class MockGenericConfigService {
+
+  private Server grpcServer;
+  private final InProcessServerBuilder serverBuilder;
+  private final ManagedChannel configChannel;
+  private final RequestContext context = RequestContext.forTenantId("default tenant");
+  private final Map<String, Value> currentValues = new LinkedHashMap<>();
+  private final ConfigServiceImplBase mockConfigService =
+      Mockito.mock(
+          ConfigServiceImplBase.class,
+          invocation -> { // Error if unmocked called so we don't hang waiting for streamobserver
+            throw new UnsupportedOperationException("Unmocked method invoked");
+          });
+
+  public MockGenericConfigService addService(BindableService service) {
+    this.serverBuilder.addService(ServerInterceptors.intercept(service, new TestInterceptor()));
+    return this;
+  }
+
+  public MockGenericConfigService() {
+    String uniqueName = InProcessServerBuilder.generateName();
+    this.configChannel = InProcessChannelBuilder.forName(uniqueName).directExecutor().build();
+    this.serverBuilder =
+        InProcessServerBuilder.forName(uniqueName)
+            .directExecutor()
+            .addService(this.mockConfigService);
+  }
+
+  public void start() {
+    try {
+      this.grpcServer = serverBuilder.build().start();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Channel channel() {
+    return this.configChannel;
+  }
+
+  public void shutdown() {
+    this.currentValues.clear();
+    this.grpcServer.shutdownNow();
+    this.configChannel.shutdownNow();
+  }
+
+  public MockGenericConfigService mockUpsert() {
+    Mockito.doAnswer(
+            invocation -> {
+              UpsertConfigRequest request = invocation.getArgument(0, UpsertConfigRequest.class);
+              StreamObserver<UpsertConfigResponse> responseStreamObserver =
+                  invocation.getArgument(1, StreamObserver.class);
+              currentValues.put(request.getContext(), request.getConfig());
+              responseStreamObserver.onNext(
+                  UpsertConfigResponse.newBuilder().setConfig(request.getConfig()).build());
+              responseStreamObserver.onCompleted();
+              return null;
+            })
+        .when(this.mockConfigService)
+        .upsertConfig(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    return this;
+  }
+
+  public MockGenericConfigService mockGetAll() {
+    Mockito.doAnswer(
+            invocation -> {
+              StreamObserver<GetAllConfigsResponse> responseStreamObserver =
+                  invocation.getArgument(1, StreamObserver.class);
+              GetAllConfigsResponse response =
+                  currentValues.values().stream()
+                      .map(value -> ContextSpecificConfig.newBuilder().setConfig(value))
+                      .map(Builder::build)
+                      .collect(
+                          Collectors.collectingAndThen(
+                              Collectors.toList(),
+                              list ->
+                                  GetAllConfigsResponse.newBuilder()
+                                      .addAllContextSpecificConfigs(list)
+                                      .build()));
+
+              responseStreamObserver.onNext(response);
+              responseStreamObserver.onCompleted();
+              return null;
+            })
+        .when(this.mockConfigService)
+        .getAllConfigs(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    return this;
+  }
+
+  public MockGenericConfigService mockDelete() {
+    Mockito.doAnswer(
+            invocation -> {
+              DeleteConfigRequest request = invocation.getArgument(0, DeleteConfigRequest.class);
+              StreamObserver<DeleteConfigResponse> responseStreamObserver =
+                  invocation.getArgument(1, StreamObserver.class);
+
+              currentValues.remove(request.getContext());
+              responseStreamObserver.onNext(DeleteConfigResponse.getDefaultInstance());
+              responseStreamObserver.onCompleted();
+              return null;
+            })
+        .when(this.mockConfigService)
+        .deleteConfig(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    return this;
+  }
+
+  public MockGenericConfigService mockGet() {
+    Mockito.doAnswer(
+            invocation -> {
+              GetConfigRequest request = invocation.getArgument(0, GetConfigRequest.class);
+              StreamObserver<GetConfigResponse> responseStreamObserver =
+                  invocation.getArgument(1, StreamObserver.class);
+
+              Value mergedValue =
+                  request.getContextsList().stream()
+                      .filter(this.currentValues::containsKey)
+                      .map(this.currentValues::get)
+                      .collect(
+                          Collectors.collectingAndThen(Collectors.toList(), this::mergeValues));
+
+              responseStreamObserver.onNext(
+                  GetConfigResponse.newBuilder().setConfig(mergedValue).build());
+              responseStreamObserver.onCompleted();
+              return null;
+            })
+        .when(this.mockConfigService)
+        .getConfig(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    return this;
+  }
+
+  private Value mergeValues(List<Value> values) {
+    return values.stream().reduce(Value.getDefaultInstance(), ConfigServiceUtils::merge);
+  }
+
+  private class TestInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      Context ctx = Context.current().withValue(RequestContext.CURRENT, context);
+      return Contexts.interceptCall(ctx, call, headers, next);
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,3 +15,8 @@ plugins {
 include(":config-service-api")
 include(":config-service-impl")
 include(":config-service")
+
+include(":config-proto-converter")
+
+include(":spaces-config-service-api")
+include(":spaces-config-service-impl")

--- a/spaces-config-service-api/build.gradle.kts
+++ b/spaces-config-service-api/build.gradle.kts
@@ -1,0 +1,39 @@
+import com.google.protobuf.gradle.*
+
+plugins {
+  `java-library`
+  id("com.google.protobuf") version "0.8.14"
+  id("org.hypertrace.publish-plugin")
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:3.14.0"
+  }
+  plugins {
+    id("grpc") {
+      artifact = "io.grpc:protoc-gen-grpc-java:1.34.1"
+    }
+  }
+  generateProtoTasks {
+    ofSourceSet("main").forEach { task ->
+      task.plugins {
+        id("grpc")
+      }
+    }
+  }
+}
+
+dependencies {
+  api("io.grpc:grpc-protobuf:1.34.1")
+  api("io.grpc:grpc-stub:1.34.1")
+  api("javax.annotation:javax.annotation-api:1.3.2")
+}
+
+sourceSets {
+  main {
+    java {
+      srcDirs("build/generated/source/proto/main/java", "build/generated/source/proto/main/grpc")
+    }
+  }
+}

--- a/spaces-config-service-api/build.gradle.kts
+++ b/spaces-config-service-api/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
   api("io.grpc:grpc-protobuf:1.34.1")
   api("io.grpc:grpc-stub:1.34.1")
   api("javax.annotation:javax.annotation-api:1.3.2")
+  constraints {
+    implementation("com.google.guava:guava:30.1-jre") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
+    }
+  }
 }
 
 sourceSets {

--- a/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/space_config_rule.proto
+++ b/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/space_config_rule.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+
+package org.hypertrace.spaces.config.service.v1;
+
+
+message SpaceConfigRule {
+  string id = 1;
+  oneof rule_data {
+    AttributeValueData attribute_value_data = 2;
+  }
+}
+
+message AttributeValueData {
+  string attribute_scope = 1;
+  string attribute_key = 2;
+}

--- a/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/space_config_rule.proto
+++ b/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/space_config_rule.proto
@@ -4,15 +4,14 @@ option java_multiple_files = true;
 
 package org.hypertrace.spaces.config.service.v1;
 
-
 message SpaceConfigRule {
   string id = 1;
   oneof rule_data {
-    AttributeValueData attribute_value_data = 2;
+    AttributeValueRuleData attribute_value_rule_data = 2;
   }
 }
 
-message AttributeValueData {
+message AttributeValueRuleData {
   string attribute_scope = 1;
   string attribute_key = 2;
 }

--- a/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/spaces_config_service.proto
+++ b/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/spaces_config_service.proto
@@ -20,7 +20,7 @@ service SpacesConfigService {
 
 message CreateRuleRequest {
   oneof rule_data {
-    AttributeValueData attribute_value_data = 1;
+    AttributeValueRuleData attribute_value_rule_data = 1;
   }
 }
 

--- a/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/spaces_config_service.proto
+++ b/spaces-config-service-api/src/main/proto/org/hypertrace/spaces/config/service/v1/spaces_config_service.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+
+package org.hypertrace.spaces.config.service.v1;
+
+import "org/hypertrace/spaces/config/service/v1/space_config_rule.proto";
+
+service SpacesConfigService {
+
+  rpc CreateRule (CreateRuleRequest) returns (CreateRuleResponse) {
+  }
+  rpc GetRules (GetRulesRequest) returns (GetRulesResponse) {
+  }
+  rpc UpdateRule (UpdateRuleRequest) returns (UpdateRuleResponse) {
+  }
+  rpc DeleteRule (DeleteRuleRequest) returns (DeleteRuleResponse) {
+  }
+}
+
+message CreateRuleRequest {
+  oneof rule_data {
+    AttributeValueData attribute_value_data = 1;
+  }
+}
+
+message CreateRuleResponse {
+  SpaceConfigRule rule = 1;
+}
+
+message GetRulesRequest {
+}
+
+message GetRulesResponse {
+  repeated SpaceConfigRule rules = 1;
+}
+
+message UpdateRuleRequest {
+  SpaceConfigRule updated_rule = 1;
+}
+
+message UpdateRuleResponse {
+  SpaceConfigRule rule = 1;
+}
+
+message DeleteRuleRequest {
+  string id = 1;
+}
+
+message DeleteRuleResponse {
+}
+

--- a/spaces-config-service-impl/build.gradle.kts
+++ b/spaces-config-service-impl/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  `java-library`
+  jacoco
+  id("org.hypertrace.jacoco-report-plugin")
+}
+
+dependencies {
+  api(project(":spaces-config-service-api"))
+  implementation(project(":config-service-api"))
+  implementation(project(":config-proto-converter"))
+  implementation("com.google.guava:guava:30.1-jre")
+  implementation("io.reactivex.rxjava3:rxjava:3.0.9")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-rx-utils:0.3.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.2")
+
+  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
+  testImplementation("org.mockito:mockito-core:3.7.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:3.7.0")
+  testImplementation(testFixtures(project(":config-service")))
+}
+
+tasks.test {
+  useJUnitPlatform()
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverter.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverter.java
@@ -1,0 +1,20 @@
+package org.hypertrace.space.config.service;
+
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+
+public interface SpaceConfigRequestConverter {
+
+  UpsertConfigRequest convertCreateRequest(CreateRuleRequest createRuleRequest);
+
+  UpsertConfigRequest convertUpdateRequest(UpdateRuleRequest updateRuleRequest);
+
+  GetAllConfigsRequest convertGetRequest(GetRulesRequest getRulesRequest);
+
+  DeleteConfigRequest convertDeleteRequest(DeleteRuleRequest deleteRuleRequest);
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImpl.java
@@ -61,8 +61,8 @@ class SpaceConfigRequestConverterImpl implements SpaceConfigRequestConverter {
         SpaceConfigRule.newBuilder().setId(this.idGenerator.generateId());
 
     switch (request.getRuleDataCase()) {
-      case ATTRIBUTE_VALUE_DATA:
-        return ruleBuilder.setAttributeValueData(request.getAttributeValueData()).build();
+      case ATTRIBUTE_VALUE_RULE_DATA:
+        return ruleBuilder.setAttributeValueRuleData(request.getAttributeValueRuleData()).build();
       case RULEDATA_NOT_SET:
       default:
         return ruleBuilder.build();

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImpl.java
@@ -1,0 +1,71 @@
+package org.hypertrace.space.config.service;
+
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+
+class SpaceConfigRequestConverterImpl implements SpaceConfigRequestConverter {
+  static final String RESOURCE_NAME = "SpacesConfigRule";
+  static final String RESOURCE_NAMESPACE = "SpacesConfigService";
+
+  private final SpaceConfigRuleConverter ruleConverter = new SpaceConfigRuleConverterImpl();
+  private final SpaceConfigRuleIdGenerator idGenerator;
+
+  SpaceConfigRequestConverterImpl(SpaceConfigRuleIdGenerator idGenerator) {
+    this.idGenerator = idGenerator;
+  }
+
+  @Override
+  public UpsertConfigRequest convertCreateRequest(CreateRuleRequest createRuleRequest) {
+    return this.buildUpsertForRule(this.generateRule(createRuleRequest));
+  }
+
+  @Override
+  public UpsertConfigRequest convertUpdateRequest(UpdateRuleRequest updateRuleRequest) {
+    return this.buildUpsertForRule(updateRuleRequest.getUpdatedRule());
+  }
+
+  @Override
+  public GetAllConfigsRequest convertGetRequest(GetRulesRequest getRulesRequest) {
+    return GetAllConfigsRequest.newBuilder()
+        .setResourceName(RESOURCE_NAME)
+        .setResourceNamespace(RESOURCE_NAMESPACE)
+        .build();
+  }
+
+  @Override
+  public DeleteConfigRequest convertDeleteRequest(DeleteRuleRequest deleteRuleRequest) {
+    return DeleteConfigRequest.newBuilder()
+        .setResourceName(RESOURCE_NAME)
+        .setResourceNamespace(RESOURCE_NAMESPACE)
+        .setContext(deleteRuleRequest.getId())
+        .build();
+  }
+
+  private UpsertConfigRequest buildUpsertForRule(SpaceConfigRule rule) {
+    return UpsertConfigRequest.newBuilder()
+        .setContext(rule.getId())
+        .setConfig(this.ruleConverter.convertToGeneric(rule))
+        .setResourceName(RESOURCE_NAME)
+        .setResourceNamespace(RESOURCE_NAMESPACE)
+        .build();
+  }
+
+  private SpaceConfigRule generateRule(CreateRuleRequest request) {
+    SpaceConfigRule.Builder ruleBuilder =
+        SpaceConfigRule.newBuilder().setId(this.idGenerator.generateId());
+
+    switch (request.getRuleDataCase()) {
+      case ATTRIBUTE_VALUE_DATA:
+        return ruleBuilder.setAttributeValueData(request.getAttributeValueData()).build();
+      case RULEDATA_NOT_SET:
+      default:
+        return ruleBuilder.build();
+    }
+  }
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidator.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidator.java
@@ -1,0 +1,19 @@
+package org.hypertrace.space.config.service;
+
+import io.reactivex.rxjava3.core.Single;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+
+public interface SpaceConfigRequestValidator {
+
+  Single<CreateRuleRequest> validateCreateRequest(RequestContext requestContext, CreateRuleRequest createRuleRequest);
+
+  Single<GetRulesRequest> validateGetRequest(RequestContext requestContext, GetRulesRequest getRulesRequest);
+
+  Single<UpdateRuleRequest> validateUpdateRequest(RequestContext requestContext, UpdateRuleRequest updateRuleRequest);
+
+  Single<DeleteRuleRequest> validateDeleteRequest(RequestContext requestContext, DeleteRuleRequest deleteRuleRequest);
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImpl.java
@@ -3,7 +3,7 @@ package org.hypertrace.space.config.service;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.grpcutils.context.RequestContext;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
 import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
@@ -17,9 +17,9 @@ class SpaceConfigRequestValidatorImpl implements SpaceConfigRequestValidator {
     return this.validateTenant(requestContext)
         .andThen(
             this.check(
-                createRuleRequest.hasAttributeValueData(),
-                "Only Attribute Value Data rules supported"))
-        .andThen(this.validateAttributeValueRule(createRuleRequest.getAttributeValueData()))
+                createRuleRequest.hasAttributeValueRuleData(),
+                "Only Attribute Value rules supported"))
+        .andThen(this.validateAttributeValueRule(createRuleRequest.getAttributeValueRuleData()))
         .toSingleDefault(createRuleRequest);
   }
 
@@ -48,18 +48,18 @@ class SpaceConfigRequestValidatorImpl implements SpaceConfigRequestValidator {
   private Completable validateRule(SpaceConfigRule rule) {
     return this.check(!rule.getId().isEmpty(), "Rule ID missing from update request")
         .andThen(
-            this.check(rule.hasAttributeValueData(), "Only Attribute Value Data rules supported"))
-        .andThen(this.validateAttributeValueRule(rule.getAttributeValueData()));
+            this.check(rule.hasAttributeValueRuleData(), "Only Attribute Value rules supported"))
+        .andThen(this.validateAttributeValueRule(rule.getAttributeValueRuleData()));
   }
 
-  private Completable validateAttributeValueRule(AttributeValueData attributeValueData) {
+  private Completable validateAttributeValueRule(AttributeValueRuleData attributeValueRuleData) {
     return this.check(
-            !attributeValueData.getAttributeScope().isEmpty(),
-            "Attribute value data rule missing attribute scope")
+            !attributeValueRuleData.getAttributeScope().isEmpty(),
+            "Attribute value rule missing attribute scope")
         .andThen(
             this.check(
-                !attributeValueData.getAttributeKey().isEmpty(),
-                "Attribute value data rule missing attribute key"));
+                !attributeValueRuleData.getAttributeKey().isEmpty(),
+                "Attribute value rule missing attribute key"));
   }
 
   private Completable validateTenant(RequestContext requestContext) {

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImpl.java
@@ -1,0 +1,75 @@
+package org.hypertrace.space.config.service;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+
+class SpaceConfigRequestValidatorImpl implements SpaceConfigRequestValidator {
+  @Override
+  public Single<CreateRuleRequest> validateCreateRequest(
+      RequestContext requestContext, CreateRuleRequest createRuleRequest) {
+    return this.validateTenant(requestContext)
+        .andThen(
+            this.check(
+                createRuleRequest.hasAttributeValueData(),
+                "Only Attribute Value Data rules supported"))
+        .andThen(this.validateAttributeValueRule(createRuleRequest.getAttributeValueData()))
+        .toSingleDefault(createRuleRequest);
+  }
+
+  @Override
+  public Single<GetRulesRequest> validateGetRequest(
+      RequestContext requestContext, GetRulesRequest getRulesRequest) {
+    return this.validateTenant(requestContext).toSingleDefault(getRulesRequest);
+  }
+
+  @Override
+  public Single<UpdateRuleRequest> validateUpdateRequest(
+      RequestContext requestContext, UpdateRuleRequest updateRuleRequest) {
+    return this.validateTenant(requestContext)
+        .andThen(this.validateRule(updateRuleRequest.getUpdatedRule()))
+        .toSingleDefault(updateRuleRequest);
+  }
+
+  @Override
+  public Single<DeleteRuleRequest> validateDeleteRequest(
+      RequestContext requestContext, DeleteRuleRequest deleteRuleRequest) {
+    return this.validateTenant(requestContext)
+        .andThen(this.check(!deleteRuleRequest.getId().isEmpty(), "ID missing from delete request"))
+        .toSingleDefault(deleteRuleRequest);
+  }
+
+  private Completable validateRule(SpaceConfigRule rule) {
+    return this.check(!rule.getId().isEmpty(), "Rule ID missing from update request")
+        .andThen(
+            this.check(rule.hasAttributeValueData(), "Only Attribute Value Data rules supported"))
+        .andThen(this.validateAttributeValueRule(rule.getAttributeValueData()));
+  }
+
+  private Completable validateAttributeValueRule(AttributeValueData attributeValueData) {
+    return this.check(
+            !attributeValueData.getAttributeScope().isEmpty(),
+            "Attribute value data rule missing attribute scope")
+        .andThen(
+            this.check(
+                !attributeValueData.getAttributeKey().isEmpty(),
+                "Attribute value data rule missing attribute key"));
+  }
+
+  private Completable validateTenant(RequestContext requestContext) {
+    return this.check(
+        requestContext.getTenantId().isPresent(), "Tenant ID is not present in request context");
+  }
+
+  private Completable check(boolean value, String errorMessage) {
+    return value
+        ? Completable.complete()
+        : Completable.error(new IllegalArgumentException(errorMessage));
+  }
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigResponseConverter.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigResponseConverter.java
@@ -1,0 +1,19 @@
+package org.hypertrace.space.config.service;
+
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.spaces.config.service.v1.CreateRuleResponse;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleResponse;
+import org.hypertrace.spaces.config.service.v1.GetRulesResponse;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleResponse;
+
+public interface SpaceConfigResponseConverter {
+  CreateRuleResponse convertCreateResponse(UpsertConfigResponse upsertConfigResponse);
+
+  UpdateRuleResponse convertUpdateResponse(UpsertConfigResponse upsertConfigResponse);
+
+  GetRulesResponse convertGetResponse(GetAllConfigsResponse getAllConfigsResponse);
+
+  DeleteRuleResponse convertDeleteResponse(DeleteConfigResponse deleteConfigResponse);
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImpl.java
@@ -1,0 +1,45 @@
+package org.hypertrace.space.config.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.spaces.config.service.v1.CreateRuleResponse;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleResponse;
+import org.hypertrace.spaces.config.service.v1.GetRulesResponse;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleResponse;
+
+class SpaceConfigResponseConverterImpl implements SpaceConfigResponseConverter {
+  private final SpaceConfigRuleConverter ruleConverter = new SpaceConfigRuleConverterImpl();
+
+  @Override
+  public CreateRuleResponse convertCreateResponse(UpsertConfigResponse upsertConfigResponse) {
+    return CreateRuleResponse.newBuilder()
+        .setRule(this.ruleConverter.convertFromGeneric(upsertConfigResponse.getConfig()))
+        .build();
+  }
+
+  @Override
+  public UpdateRuleResponse convertUpdateResponse(UpsertConfigResponse upsertConfigResponse) {
+    return UpdateRuleResponse.newBuilder()
+        .setRule(this.ruleConverter.convertFromGeneric(upsertConfigResponse.getConfig()))
+        .build();
+  }
+
+  @Override
+  public GetRulesResponse convertGetResponse(GetAllConfigsResponse getAllConfigsResponse) {
+    List<SpaceConfigRule> rules =
+        getAllConfigsResponse.getContextSpecificConfigsList().stream()
+            .map(wrapper -> this.ruleConverter.convertFromGeneric(wrapper.getConfig()))
+            .collect(Collectors.toList());
+
+    return GetRulesResponse.newBuilder().addAllRules(rules).build();
+  }
+
+  @Override
+  public DeleteRuleResponse convertDeleteResponse(DeleteConfigResponse deleteConfigResponse) {
+    return DeleteRuleResponse.getDefaultInstance();
+  }
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleConverter.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleConverter.java
@@ -1,0 +1,11 @@
+package org.hypertrace.space.config.service;
+
+import com.google.protobuf.Value;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+
+public interface SpaceConfigRuleConverter {
+
+  Value convertToGeneric(SpaceConfigRule rule);
+
+  SpaceConfigRule convertFromGeneric(Value config);
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImpl.java
@@ -1,0 +1,29 @@
+package org.hypertrace.space.config.service;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Value;
+import org.hypertrace.config.proto.converter.ConfigProtoConverter;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+
+class SpaceConfigRuleConverterImpl implements SpaceConfigRuleConverter {
+
+  @Override
+  public Value convertToGeneric(SpaceConfigRule rule) {
+    try {
+      return ConfigProtoConverter.convertToValue(rule);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public SpaceConfigRule convertFromGeneric(Value config) {
+    SpaceConfigRule.Builder builder = SpaceConfigRule.newBuilder();
+    try {
+      ConfigProtoConverter.mergeFromValue(config, builder);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+    return builder.build();
+  }
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleIdGenerator.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpaceConfigRuleIdGenerator.java
@@ -1,0 +1,10 @@
+package org.hypertrace.space.config.service;
+
+import java.util.UUID;
+
+class SpaceConfigRuleIdGenerator {
+
+  String generateId() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpacesConfigServiceImpl.java
+++ b/spaces-config-service-impl/src/main/java/org/hypertrace/space/config/service/SpacesConfigServiceImpl.java
@@ -1,0 +1,107 @@
+package org.hypertrace.space.config.service;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.Channel;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Function;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceFutureStub;
+import org.hypertrace.core.grpcutils.client.RequestContextClientCallCredsProviderFactory;
+import org.hypertrace.core.grpcutils.client.rx.GrpcRxExecutionContext;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.grpcutils.server.rx.ServerCallStreamRxObserver;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.CreateRuleResponse;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleResponse;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesResponse;
+import org.hypertrace.spaces.config.service.v1.SpacesConfigServiceGrpc.SpacesConfigServiceImplBase;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleResponse;
+
+public class SpacesConfigServiceImpl extends SpacesConfigServiceImplBase {
+  private final ConfigServiceFutureStub configServiceStub;
+  private final SpaceConfigRequestValidator requestValidator;
+  private final SpaceConfigRequestConverter requestConverter;
+  private final SpaceConfigResponseConverter responseConverter;
+
+  public SpacesConfigServiceImpl(Channel configChannel) {
+    this.configServiceStub =
+        ConfigServiceGrpc.newFutureStub(configChannel)
+            .withCallCredentials(
+                RequestContextClientCallCredsProviderFactory.getClientCallCredsProvider().get());
+    this.requestConverter = new SpaceConfigRequestConverterImpl(new SpaceConfigRuleIdGenerator());
+    this.requestValidator = new SpaceConfigRequestValidatorImpl();
+    this.responseConverter = new SpaceConfigResponseConverterImpl();
+  }
+
+  @Override
+  public void createRule(
+      CreateRuleRequest request, StreamObserver<CreateRuleResponse> responseObserver) {
+    RequestContext context = RequestContext.CURRENT.get();
+
+    this.requestValidator
+        .validateCreateRequest(context, request)
+        .map(this.requestConverter::convertCreateRequest)
+        .flatMap(this.callInContext(context, this.configServiceStub::upsertConfig)::apply)
+        .map(this.responseConverter::convertCreateResponse)
+        .subscribe(
+            new ServerCallStreamRxObserver<>(
+                (ServerCallStreamObserver<CreateRuleResponse>) responseObserver));
+  }
+
+  @Override
+  public void getRules(GetRulesRequest request, StreamObserver<GetRulesResponse> responseObserver) {
+    RequestContext context = RequestContext.CURRENT.get();
+
+    this.requestValidator
+        .validateGetRequest(context, request)
+        .map(this.requestConverter::convertGetRequest)
+        .flatMap(this.callInContext(context, this.configServiceStub::getAllConfigs)::apply)
+        .map(this.responseConverter::convertGetResponse)
+        .subscribe(
+            new ServerCallStreamRxObserver<>(
+                (ServerCallStreamObserver<GetRulesResponse>) responseObserver));
+  }
+
+  @Override
+  public void updateRule(
+      UpdateRuleRequest request, StreamObserver<UpdateRuleResponse> responseObserver) {
+    RequestContext context = RequestContext.CURRENT.get();
+
+    this.requestValidator
+        .validateUpdateRequest(context, request)
+        .map(this.requestConverter::convertUpdateRequest)
+        .flatMap(this.callInContext(context, this.configServiceStub::upsertConfig)::apply)
+        .map(this.responseConverter::convertUpdateResponse)
+        .subscribe(
+            new ServerCallStreamRxObserver<>(
+                (ServerCallStreamObserver<UpdateRuleResponse>) responseObserver));
+  }
+
+  @Override
+  public void deleteRule(
+      DeleteRuleRequest request, StreamObserver<DeleteRuleResponse> responseObserver) {
+    RequestContext context = RequestContext.CURRENT.get();
+
+    this.requestValidator
+        .validateDeleteRequest(context, request)
+        .map(this.requestConverter::convertDeleteRequest)
+        .flatMap(this.callInContext(context, this.configServiceStub::deleteConfig)::apply)
+        .map(this.responseConverter::convertDeleteResponse)
+        .subscribe(
+            new ServerCallStreamRxObserver<>(
+                (ServerCallStreamObserver<DeleteRuleResponse>) responseObserver));
+  }
+
+  private <TRequest, TResponse> Function<TRequest, Single<TResponse>> callInContext(
+      RequestContext context, Function<TRequest, ListenableFuture<TResponse>> callable) {
+    return request ->
+        GrpcRxExecutionContext.forContext(context)
+            .call(() -> callable.apply(request))
+            .flatMap(Single::fromFuture);
+  }
+}

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImplTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.hypertrace.config.service.v1.DeleteConfigRequest;
 import org.hypertrace.config.service.v1.GetAllConfigsRequest;
 import org.hypertrace.config.service.v1.UpsertConfigRequest;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
 import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
@@ -32,8 +32,8 @@ class SpaceConfigRequestConverterImplTest {
   private static final SpaceConfigRule RULE =
       SpaceConfigRule.newBuilder()
           .setId(TEST_ID)
-          .setAttributeValueData(
-              AttributeValueData.newBuilder()
+          .setAttributeValueRuleData(
+              AttributeValueRuleData.newBuilder()
                   .setAttributeKey(TEST_KEY)
                   .setAttributeScope(TEST_SCOPE))
           .build();
@@ -46,7 +46,7 @@ class SpaceConfigRequestConverterImplTest {
                       Map.of(
                           "id",
                           Value.newBuilder().setStringValue(TEST_ID).build(),
-                          "attributeValueData",
+                          "attributeValueRuleData",
                           Value.newBuilder()
                               .setStructValue(
                                   Struct.newBuilder()
@@ -77,7 +77,7 @@ class SpaceConfigRequestConverterImplTest {
     UpsertConfigRequest convertedRequest =
         this.converter.convertCreateRequest(
             CreateRuleRequest.newBuilder()
-                .setAttributeValueData(RULE.getAttributeValueData())
+                .setAttributeValueRuleData(RULE.getAttributeValueRuleData())
                 .build());
 
     assertEquals(VALUE, convertedRequest.getConfig());

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestConverterImplTest.java
@@ -1,0 +1,119 @@
+package org.hypertrace.space.config.service;
+
+import static org.hypertrace.space.config.service.SpaceConfigRequestConverterImpl.RESOURCE_NAME;
+import static org.hypertrace.space.config.service.SpaceConfigRequestConverterImpl.RESOURCE_NAMESPACE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.Map;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SpaceConfigRequestConverterImplTest {
+  private static final String TEST_ID = "test-id";
+  private static final String TEST_KEY = "test-key";
+  private static final String TEST_SCOPE = "test-scope";
+
+  private static final SpaceConfigRule RULE =
+      SpaceConfigRule.newBuilder()
+          .setId(TEST_ID)
+          .setAttributeValueData(
+              AttributeValueData.newBuilder()
+                  .setAttributeKey(TEST_KEY)
+                  .setAttributeScope(TEST_SCOPE))
+          .build();
+
+  private static final Value VALUE =
+      Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putAllFields(
+                      Map.of(
+                          "id",
+                          Value.newBuilder().setStringValue(TEST_ID).build(),
+                          "attributeValueData",
+                          Value.newBuilder()
+                              .setStructValue(
+                                  Struct.newBuilder()
+                                      .putFields(
+                                          "attributeKey",
+                                          Value.newBuilder().setStringValue(TEST_KEY).build())
+                                      .putFields(
+                                          "attributeScope",
+                                          Value.newBuilder().setStringValue(TEST_SCOPE).build())
+                                      .build())
+                              .build()))
+                  .build())
+          .build();
+
+  @Mock SpaceConfigRuleIdGenerator mockIdGenerator;
+  private SpaceConfigRequestConverter converter;
+
+  @BeforeEach
+  void beforeEach() {
+    this.converter = new SpaceConfigRequestConverterImpl(this.mockIdGenerator);
+  }
+
+  @Test
+  void convertsCreateRequest() {
+
+    when(this.mockIdGenerator.generateId()).thenReturn(TEST_ID);
+
+    UpsertConfigRequest convertedRequest =
+        this.converter.convertCreateRequest(
+            CreateRuleRequest.newBuilder()
+                .setAttributeValueData(RULE.getAttributeValueData())
+                .build());
+
+    assertEquals(VALUE, convertedRequest.getConfig());
+    assertEquals(RESOURCE_NAME, convertedRequest.getResourceName());
+    assertEquals(RESOURCE_NAMESPACE, convertedRequest.getResourceNamespace());
+    assertEquals(TEST_ID, convertedRequest.getContext());
+  }
+
+  @Test
+  void convertsUpdateRequest() {
+    UpsertConfigRequest convertedRequest =
+        this.converter.convertUpdateRequest(
+            UpdateRuleRequest.newBuilder().setUpdatedRule(RULE).build());
+
+    assertEquals(VALUE, convertedRequest.getConfig());
+    assertEquals(RESOURCE_NAME, convertedRequest.getResourceName());
+    assertEquals(RESOURCE_NAMESPACE, convertedRequest.getResourceNamespace());
+    assertEquals(TEST_ID, convertedRequest.getContext());
+  }
+
+  @Test
+  void convertsGetRequest() {
+    GetAllConfigsRequest convertedRequest =
+        this.converter.convertGetRequest(GetRulesRequest.getDefaultInstance());
+
+    assertEquals(RESOURCE_NAME, convertedRequest.getResourceName());
+    assertEquals(RESOURCE_NAMESPACE, convertedRequest.getResourceNamespace());
+  }
+
+  @Test
+  void convertsDeleteRequest() {
+    DeleteConfigRequest convertedRequest =
+        this.converter.convertDeleteRequest(DeleteRuleRequest.newBuilder().setId(TEST_ID).build());
+
+    assertEquals(RESOURCE_NAME, convertedRequest.getResourceName());
+    assertEquals(RESOURCE_NAMESPACE, convertedRequest.getResourceNamespace());
+    assertEquals(TEST_ID, convertedRequest.getContext());
+  }
+}

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImplTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.hypertrace.core.grpcutils.context.RequestContext;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
 import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
@@ -28,14 +28,16 @@ class SpaceConfigRequestValidatorImplTest {
   void validatesCreateRequest() {
     CreateRuleRequest validRequest =
         CreateRuleRequest.newBuilder()
-            .setAttributeValueData(
-                AttributeValueData.newBuilder().setAttributeScope("scope").setAttributeKey("key"))
+            .setAttributeValueRuleData(
+                AttributeValueRuleData.newBuilder()
+                    .setAttributeScope("scope")
+                    .setAttributeKey("key"))
             .build();
 
     CreateRuleRequest invalidRequest =
         validRequest.toBuilder()
-            .setAttributeValueData(
-                AttributeValueData.newBuilder().setAttributeScope("scope")) // missing key
+            .setAttributeValueRuleData(
+                AttributeValueRuleData.newBuilder().setAttributeScope("scope")) // missing key
             .build();
 
     when(requestContext.getTenantId()).thenReturn(Optional.empty());
@@ -113,8 +115,8 @@ class SpaceConfigRequestValidatorImplTest {
             .setUpdatedRule(
                 SpaceConfigRule.newBuilder()
                     .setId("id")
-                    .setAttributeValueData(
-                        AttributeValueData.newBuilder()
+                    .setAttributeValueRuleData(
+                        AttributeValueRuleData.newBuilder()
                             .setAttributeScope("scope")
                             .setAttributeKey("key")))
             .build();
@@ -128,8 +130,8 @@ class SpaceConfigRequestValidatorImplTest {
         validRequest.toBuilder()
             .setUpdatedRule(
                 validRequest.getUpdatedRule().toBuilder()
-                    .setAttributeValueData(
-                        validRequest.getUpdatedRule().getAttributeValueData().toBuilder()
+                    .setAttributeValueRuleData(
+                        validRequest.getUpdatedRule().getAttributeValueRuleData().toBuilder()
                             .clearAttributeKey()))
             .build();
 

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRequestValidatorImplTest.java
@@ -1,0 +1,165 @@
+package org.hypertrace.space.config.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SpaceConfigRequestValidatorImplTest {
+
+  @Mock RequestContext requestContext;
+
+  SpaceConfigRequestValidator requestValidator = new SpaceConfigRequestValidatorImpl();
+
+  @Test
+  void validatesCreateRequest() {
+    CreateRuleRequest validRequest =
+        CreateRuleRequest.newBuilder()
+            .setAttributeValueData(
+                AttributeValueData.newBuilder().setAttributeScope("scope").setAttributeKey("key"))
+            .build();
+
+    CreateRuleRequest invalidRequest =
+        validRequest.toBuilder()
+            .setAttributeValueData(
+                AttributeValueData.newBuilder().setAttributeScope("scope")) // missing key
+            .build();
+
+    when(requestContext.getTenantId()).thenReturn(Optional.empty());
+    // Valid request, no tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateCreateRequest(requestContext, validRequest).blockingGet());
+
+    when(requestContext.getTenantId()).thenReturn(Optional.of("tenant-id"));
+
+    // Missing data entirely on request, valid tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            requestValidator
+                .validateCreateRequest(requestContext, CreateRuleRequest.getDefaultInstance())
+                .blockingGet());
+
+    // Invalid request, valid tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateCreateRequest(requestContext, invalidRequest).blockingGet());
+
+    // Valid request, valid tenant
+    assertEquals(
+        validRequest,
+        requestValidator.validateCreateRequest(requestContext, validRequest).blockingGet());
+  }
+
+  @Test
+  void validatesGetRequest() {
+    // no data in get request, nothing to validate
+    GetRulesRequest request = GetRulesRequest.getDefaultInstance();
+
+    // No tenant
+    when(requestContext.getTenantId()).thenReturn(Optional.empty());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateGetRequest(requestContext, request).blockingGet());
+
+    // Valid tenant
+    when(requestContext.getTenantId()).thenReturn(Optional.of("tenant-id"));
+    assertEquals(
+        request, requestValidator.validateGetRequest(requestContext, request).blockingGet());
+  }
+
+  @Test
+  void validatesDeleteRequest() {
+    DeleteRuleRequest validRequest = DeleteRuleRequest.newBuilder().setId("some-id").build();
+    DeleteRuleRequest invalidRequest = DeleteRuleRequest.getDefaultInstance();
+
+    when(requestContext.getTenantId()).thenReturn(Optional.empty());
+    // Valid request, no tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateDeleteRequest(requestContext, validRequest).blockingGet());
+
+    when(requestContext.getTenantId()).thenReturn(Optional.of("tenant-id"));
+
+    // Invalid request, valid tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateDeleteRequest(requestContext, invalidRequest).blockingGet());
+
+    // Valid request, valid tenant
+    assertEquals(
+        validRequest,
+        requestValidator.validateDeleteRequest(requestContext, validRequest).blockingGet());
+  }
+
+  @Test
+  void validateUpdateRequest() {
+    UpdateRuleRequest validRequest =
+        UpdateRuleRequest.newBuilder()
+            .setUpdatedRule(
+                SpaceConfigRule.newBuilder()
+                    .setId("id")
+                    .setAttributeValueData(
+                        AttributeValueData.newBuilder()
+                            .setAttributeScope("scope")
+                            .setAttributeKey("key")))
+            .build();
+
+    UpdateRuleRequest invalidRequestNoId =
+        validRequest.toBuilder()
+            .setUpdatedRule(validRequest.getUpdatedRule().toBuilder().clearId())
+            .build();
+
+    UpdateRuleRequest invalidRequestNoKey =
+        validRequest.toBuilder()
+            .setUpdatedRule(
+                validRequest.getUpdatedRule().toBuilder()
+                    .setAttributeValueData(
+                        validRequest.getUpdatedRule().getAttributeValueData().toBuilder()
+                            .clearAttributeKey()))
+            .build();
+
+    when(requestContext.getTenantId()).thenReturn(Optional.empty());
+    // Valid request, no tenant
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> requestValidator.validateUpdateRequest(requestContext, validRequest).blockingGet());
+
+    when(requestContext.getTenantId()).thenReturn(Optional.of("tenant-id"));
+
+    // Invalid request missing id
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            requestValidator
+                .validateUpdateRequest(requestContext, invalidRequestNoId)
+                .blockingGet());
+
+    // Invalid request missing attribute key
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            requestValidator
+                .validateUpdateRequest(requestContext, invalidRequestNoKey)
+                .blockingGet());
+
+    // Valid request, valid tenant
+    assertEquals(
+        validRequest,
+        requestValidator.validateUpdateRequest(requestContext, validRequest).blockingGet());
+  }
+}

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImplTest.java
@@ -10,7 +10,7 @@ import org.hypertrace.config.service.v1.ContextSpecificConfig;
 import org.hypertrace.config.service.v1.DeleteConfigResponse;
 import org.hypertrace.config.service.v1.GetAllConfigsResponse;
 import org.hypertrace.config.service.v1.UpsertConfigResponse;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.DeleteRuleResponse;
 import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,8 +26,8 @@ class SpaceConfigResponseConverterImplTest {
   private static final SpaceConfigRule RULE =
       SpaceConfigRule.newBuilder()
           .setId(TEST_ID)
-          .setAttributeValueData(
-              AttributeValueData.newBuilder()
+          .setAttributeValueRuleData(
+              AttributeValueRuleData.newBuilder()
                   .setAttributeKey(TEST_KEY)
                   .setAttributeScope(TEST_SCOPE))
           .build();
@@ -40,7 +40,7 @@ class SpaceConfigResponseConverterImplTest {
                       Map.of(
                           "id",
                           Value.newBuilder().setStringValue(TEST_ID).build(),
-                          "attributeValueData",
+                          "attributeValueRuleData",
                           Value.newBuilder()
                               .setStructValue(
                                   Struct.newBuilder()

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigResponseConverterImplTest.java
@@ -1,0 +1,103 @@
+package org.hypertrace.space.config.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleResponse;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class SpaceConfigResponseConverterImplTest {
+
+  private static final String TEST_ID = "test-id";
+  private static final String TEST_KEY = "test-key";
+  private static final String TEST_SCOPE = "test-scope";
+
+  private static final SpaceConfigRule RULE =
+      SpaceConfigRule.newBuilder()
+          .setId(TEST_ID)
+          .setAttributeValueData(
+              AttributeValueData.newBuilder()
+                  .setAttributeKey(TEST_KEY)
+                  .setAttributeScope(TEST_SCOPE))
+          .build();
+
+  private static final Value VALUE =
+      Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putAllFields(
+                      Map.of(
+                          "id",
+                          Value.newBuilder().setStringValue(TEST_ID).build(),
+                          "attributeValueData",
+                          Value.newBuilder()
+                              .setStructValue(
+                                  Struct.newBuilder()
+                                      .putFields(
+                                          "attributeKey",
+                                          Value.newBuilder().setStringValue(TEST_KEY).build())
+                                      .putFields(
+                                          "attributeScope",
+                                          Value.newBuilder().setStringValue(TEST_SCOPE).build())
+                                      .build())
+                              .build()))
+                  .build())
+          .build();
+
+  @Mock SpaceConfigRuleIdGenerator mockIdGenerator;
+  private SpaceConfigResponseConverter converter;
+
+  @BeforeEach
+  void beforeEach() {
+    this.converter = new SpaceConfigResponseConverterImpl();
+  }
+
+  @Test
+  void convertsCreateResponse() {
+    assertEquals(
+        RULE,
+        this.converter
+            .convertCreateResponse(UpsertConfigResponse.newBuilder().setConfig(VALUE).build())
+            .getRule());
+  }
+
+  @Test
+  void convertsUpdateResponse() {
+    assertEquals(
+        RULE,
+        this.converter
+            .convertUpdateResponse(UpsertConfigResponse.newBuilder().setConfig(VALUE).build())
+            .getRule());
+  }
+
+  @Test
+  void convertsGetAllResponse() {
+    assertEquals(
+        List.of(RULE),
+        this.converter
+            .convertGetResponse(
+                GetAllConfigsResponse.newBuilder()
+                    .addContextSpecificConfigs(
+                        ContextSpecificConfig.newBuilder().setConfig(VALUE).setContext(TEST_ID))
+                    .build())
+            .getRulesList());
+  }
+
+  @Test
+  void convertsDeleteResponse() {
+    assertEquals(
+        DeleteRuleResponse.getDefaultInstance(),
+        this.converter.convertDeleteResponse(DeleteConfigResponse.getDefaultInstance()));
+  }
+}

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImplTest.java
@@ -7,20 +7,19 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import java.util.Map;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
 import org.junit.jupiter.api.Test;
 
 class SpaceConfigRuleConverterImplTest {
 
-  private static final SpaceConfigRuleConverterImpl CONVERTER =
-      new SpaceConfigRuleConverterImpl();
+  private static final SpaceConfigRuleConverterImpl CONVERTER = new SpaceConfigRuleConverterImpl();
 
   private static final SpaceConfigRule RULE =
       SpaceConfigRule.newBuilder()
           .setId("test-id")
-          .setAttributeValueData(
-              AttributeValueData.newBuilder()
+          .setAttributeValueRuleData(
+              AttributeValueRuleData.newBuilder()
                   .setAttributeKey("attrKey")
                   .setAttributeScope("attrScope"))
           .build();
@@ -33,7 +32,7 @@ class SpaceConfigRuleConverterImplTest {
                       Map.of(
                           "id",
                           Value.newBuilder().setStringValue("test-id").build(),
-                          "attributeValueData",
+                          "attributeValueRuleData",
                           Value.newBuilder()
                               .setStructValue(
                                   Struct.newBuilder()

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpaceConfigRuleConverterImplTest.java
@@ -1,0 +1,75 @@
+package org.hypertrace.space.config.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.Map;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.junit.jupiter.api.Test;
+
+class SpaceConfigRuleConverterImplTest {
+
+  private static final SpaceConfigRuleConverterImpl CONVERTER =
+      new SpaceConfigRuleConverterImpl();
+
+  private static final SpaceConfigRule RULE =
+      SpaceConfigRule.newBuilder()
+          .setId("test-id")
+          .setAttributeValueData(
+              AttributeValueData.newBuilder()
+                  .setAttributeKey("attrKey")
+                  .setAttributeScope("attrScope"))
+          .build();
+
+  private static final Value VALUE =
+      Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putAllFields(
+                      Map.of(
+                          "id",
+                          Value.newBuilder().setStringValue("test-id").build(),
+                          "attributeValueData",
+                          Value.newBuilder()
+                              .setStructValue(
+                                  Struct.newBuilder()
+                                      .putFields(
+                                          "attributeKey",
+                                          Value.newBuilder().setStringValue("attrKey").build())
+                                      .putFields(
+                                          "attributeScope",
+                                          Value.newBuilder().setStringValue("attrScope").build())
+                                      .build())
+                              .build()))
+                  .build())
+          .build();
+
+  @Test
+  void convertsFromRule() {
+    assertEquals(VALUE, CONVERTER.convertToGeneric(RULE));
+  }
+
+  @Test
+  void convertsToRule() {
+    assertEquals(RULE, CONVERTER.convertFromGeneric(VALUE));
+  }
+
+  @Test
+  void errorsOnInvalidValue() {
+    // Proto are pretty resilient - missing fields are defaulted, extra fields are ignored. To break
+    // it, we change the field's type here
+    Value mismatchedValue =
+        Value.newBuilder()
+            .setStructValue(
+                Struct.newBuilder()
+                    .putFields(
+                        "id",
+                        Value.newBuilder().setListValue(ListValue.getDefaultInstance()).build()))
+            .build();
+    assertThrows(RuntimeException.class, () -> CONVERTER.convertFromGeneric(mismatchedValue));
+  }
+}

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpacesConfigServiceImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpacesConfigServiceImplTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import java.util.List;
 import org.hypertrace.config.service.MockGenericConfigService;
-import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
 import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
@@ -43,14 +43,14 @@ class SpacesConfigServiceImplTest {
   @Test
   void createReadUpdateReadDelete() {
 
-    AttributeValueData attributeValueData1 =
-        AttributeValueData.newBuilder()
+    AttributeValueRuleData attributeValueRuleData1 =
+        AttributeValueRuleData.newBuilder()
             .setAttributeScope("attrScope")
             .setAttributeKey("attrKey1")
             .build();
 
-    AttributeValueData attributeValueData2 =
-        AttributeValueData.newBuilder()
+    AttributeValueRuleData attributeValueRuleData2 =
+        AttributeValueRuleData.newBuilder()
             .setAttributeScope("attrScope")
             .setAttributeKey("attrKey2")
             .build();
@@ -58,16 +58,20 @@ class SpacesConfigServiceImplTest {
     SpaceConfigRule createdRule1 =
         this.spacesStub
             .createRule(
-                CreateRuleRequest.newBuilder().setAttributeValueData(attributeValueData1).build())
+                CreateRuleRequest.newBuilder()
+                    .setAttributeValueRuleData(attributeValueRuleData1)
+                    .build())
             .getRule();
 
-    assertEquals(attributeValueData1, createdRule1.getAttributeValueData());
+    assertEquals(attributeValueRuleData1, createdRule1.getAttributeValueRuleData());
     assertFalse(createdRule1.getId().isEmpty());
 
     SpaceConfigRule createdRule2 =
         this.spacesStub
             .createRule(
-                CreateRuleRequest.newBuilder().setAttributeValueData(attributeValueData2).build())
+                CreateRuleRequest.newBuilder()
+                    .setAttributeValueRuleData(attributeValueRuleData2)
+                    .build())
             .getRule();
 
     assertIterableEquals(
@@ -76,8 +80,8 @@ class SpacesConfigServiceImplTest {
 
     SpaceConfigRule ruleToUpdate =
         createdRule1.toBuilder()
-            .setAttributeValueData(
-                attributeValueData1.toBuilder().setAttributeKey("updatedAttrKey1"))
+            .setAttributeValueRuleData(
+                attributeValueRuleData1.toBuilder().setAttributeKey("updatedAttrKey1"))
             .build();
 
     SpaceConfigRule updatedRule1 =

--- a/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpacesConfigServiceImplTest.java
+++ b/spaces-config-service-impl/src/test/java/org/hypertrace/space/config/service/SpacesConfigServiceImplTest.java
@@ -1,0 +1,100 @@
+package org.hypertrace.space.config.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.List;
+import org.hypertrace.config.service.MockGenericConfigService;
+import org.hypertrace.spaces.config.service.v1.AttributeValueData;
+import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
+import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.SpacesConfigServiceGrpc;
+import org.hypertrace.spaces.config.service.v1.SpacesConfigServiceGrpc.SpacesConfigServiceBlockingStub;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpacesConfigServiceImplTest {
+  SpacesConfigServiceBlockingStub spacesStub;
+  MockGenericConfigService mockGenericConfigService;
+
+  @BeforeEach
+  void beforeEach() {
+    this.mockGenericConfigService =
+        new MockGenericConfigService().mockUpsert().mockGetAll().mockDelete();
+
+    this.mockGenericConfigService
+        .addService(new SpacesConfigServiceImpl(this.mockGenericConfigService.channel()))
+        .start();
+
+    this.spacesStub =
+        SpacesConfigServiceGrpc.newBlockingStub(this.mockGenericConfigService.channel());
+  }
+
+  @AfterEach
+  void afterEach() {
+    this.mockGenericConfigService.shutdown();
+  }
+
+  @Test
+  void createReadUpdateReadDelete() {
+
+    AttributeValueData attributeValueData1 =
+        AttributeValueData.newBuilder()
+            .setAttributeScope("attrScope")
+            .setAttributeKey("attrKey1")
+            .build();
+
+    AttributeValueData attributeValueData2 =
+        AttributeValueData.newBuilder()
+            .setAttributeScope("attrScope")
+            .setAttributeKey("attrKey2")
+            .build();
+
+    SpaceConfigRule createdRule1 =
+        this.spacesStub
+            .createRule(
+                CreateRuleRequest.newBuilder().setAttributeValueData(attributeValueData1).build())
+            .getRule();
+
+    assertEquals(attributeValueData1, createdRule1.getAttributeValueData());
+    assertFalse(createdRule1.getId().isEmpty());
+
+    SpaceConfigRule createdRule2 =
+        this.spacesStub
+            .createRule(
+                CreateRuleRequest.newBuilder().setAttributeValueData(attributeValueData2).build())
+            .getRule();
+
+    assertIterableEquals(
+        List.of(createdRule1, createdRule2),
+        this.spacesStub.getRules(GetRulesRequest.getDefaultInstance()).getRulesList());
+
+    SpaceConfigRule ruleToUpdate =
+        createdRule1.toBuilder()
+            .setAttributeValueData(
+                attributeValueData1.toBuilder().setAttributeKey("updatedAttrKey1"))
+            .build();
+
+    SpaceConfigRule updatedRule1 =
+        this.spacesStub
+            .updateRule(UpdateRuleRequest.newBuilder().setUpdatedRule(ruleToUpdate).build())
+            .getRule();
+
+    assertEquals(ruleToUpdate, updatedRule1);
+
+    assertIterableEquals(
+        List.of(updatedRule1, createdRule2),
+        this.spacesStub.getRules(GetRulesRequest.getDefaultInstance()).getRulesList());
+
+    this.spacesStub.deleteRule(DeleteRuleRequest.newBuilder().setId(createdRule2.getId()).build());
+
+    assertIterableEquals(
+        List.of(updatedRule1),
+        this.spacesStub.getRules(GetRulesRequest.getDefaultInstance()).getRulesList());
+  }
+}


### PR DESCRIPTION
Spaces config service allows for managing space configuration rules to be evaluated during the ingestion pipeline in the SpaceEnricher, and is used as part of hypertrace/hypertrace#142 . Management of these rules will be exposed externally via graphql.

By the time the tests were written on this one, the PR got pretty large - although not a significant amount of logic. If it makes the review easier, I can split a few things up.