### PR TITLE
fixing an initialisation issue when using postgres as docstore

### DIFF
--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -55,7 +55,7 @@ public class DocumentConfigStore implements ConfigStore {
   @Override
   public void init(Config config) {
     datastore = initDataStore(config);
-    this.collection = getOrCreateCollection(datastore);
+    this.collection = this.datastore.getCollection(CONFIGURATIONS_COLLECTION);;
   }
 
   private Datastore initDataStore(Config config) {
@@ -63,16 +63,6 @@ public class DocumentConfigStore implements ConfigStore {
     String dataStoreType = docStoreConfig.getString(DATA_STORE_TYPE);
     Config dataStoreConfig = docStoreConfig.getConfig(dataStoreType);
     return DatastoreProvider.getDatastore(dataStoreType, dataStoreConfig);
-  }
-
-  private Collection getOrCreateCollection(Datastore datastore) {
-    if (!datastore.listCollections().contains(CONFIGURATIONS_COLLECTION)) {
-      if (!datastore.createCollection(CONFIGURATIONS_COLLECTION, Collections.emptyMap())) {
-        throw new RuntimeException(
-            "Failed to create collection:" + CONFIGURATIONS_COLLECTION + " in document store");
-      }
-    }
-    return datastore.getCollection(CONFIGURATIONS_COLLECTION);
   }
 
   @Override


### PR DESCRIPTION
The listCollection api returns the list of tables prefix with db name.
```
INFO  o.h.c.s.s.DocumentConfigStore - list of collections:[default_db.attribute_metadata, default_db.config_bootstrap_status, default_db.configurations, default_db.entity_types, default_db.entity_type_relations]
```
So, the method `getOrCreateCollection` was failing on postgres collection side if a table already exists.

```
postgres                | 2021-02-01 08:16:20.136 UTC [76] ERROR:  relation "configurations" already exists
```

Currently, there is an assumption on dbname (`default_db`) while using mongo as docstore, we will have to fix that first. For now, 
We don't have to explicitly check if the collection exists while using `mongo` as docstore. On postgres side, it has been taken care of inside getCollection api.
