### PR TITLE
Upsert overriding with the new config to be upserted

### DIFF
--- a/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
+++ b/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
@@ -7,8 +7,8 @@ package org.hypertrace.config.service.v1;
 import "google/protobuf/struct.proto";
 
 service ConfigService {
-  // Merges the specified config with the existing config and upserts the
-  // resulting config into the store. Also returns the config which is upserted.
+  // Overrides the specified config with the config provided and upserts the
+  // provided config into the store. Also returns the config which is upserted.
   rpc UpsertConfig(UpsertConfigRequest) returns (UpsertConfigResponse) {}
 
   // Gets the config for the specified request

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
@@ -42,11 +42,9 @@ public class ConfigServiceGrpcImpl extends ConfigServiceGrpc.ConfigServiceImplBa
       StreamObserver<UpsertConfigResponse> responseObserver) {
     try {
       ConfigResource configResource = getConfigResource(request);
-      Value existingConfig = configStore.getConfig(configResource);
-      Value resultingConfig = merge(existingConfig, request.getConfig());
-      configStore.writeConfig(configResource, getUserId(), resultingConfig);
+      configStore.writeConfig(configResource, getUserId(), request.getConfig());
       responseObserver.onNext(UpsertConfigResponse.newBuilder()
-          .setConfig(resultingConfig)
+          .setConfig(request.getConfig())
           .build());
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
@@ -79,7 +79,7 @@ class ConfigServiceGrpcImplTest {
     List<UpsertConfigResponse> actualResponseList = upsertConfigResponseCaptor.getAllValues();
     assertEquals(3, actualResponseList.size());
     assertEquals(config1, actualResponseList.get(0).getConfig());
-    assertEquals(mergedConfig, actualResponseList.get(1).getConfig());
+    assertEquals(config2, actualResponseList.get(1).getConfig());
     assertEquals(config2, actualResponseList.get(2).getConfig());
   }
 

--- a/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
+++ b/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
@@ -92,7 +92,7 @@ public class ConfigServiceIntegrationTest {
     // upsert second version of config for tenant-1
     upsertConfigResponse = upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1,
         Optional.empty(), config2);
-    assertEquals(config3, upsertConfigResponse.getConfig());
+    assertEquals(config2, upsertConfigResponse.getConfig());
 
     // test across tenants - upsert first version of config for tenant-2
     upsertConfigResponse = upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2,


### PR DESCRIPTION
This change was needed to support the update of the fields with default proto value. We can't distinguish if the default value was being set(updated) or it's just the default proto value.
eg: If a flag  in config is marked as true, now we want to update it to false, it's not possible with the current merging/partial update logic. So, for now, support is for full update of the config.