### PR TITLE
chore: bump doc-store version to include SQLi fix

### DIFF
--- a/config-service-impl/build.gradle.kts
+++ b/config-service-impl/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   implementation("com.typesafe:config:1.4.0")
   implementation("org.slf4j:slf4j-api:1.7.30")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.5")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.3")
 
   annotationProcessor("org.projectlombok:lombok:1.18.12")


### PR DESCRIPTION
Updates doc-store version to include SQLi fix - hypertrace/document-store#30