### PR TITLE
chore: bump doc-store version to include postgres impl of exits, not-exits and neq

### DIFF
--- a/config-service-impl/build.gradle.kts
+++ b/config-service-impl/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   implementation("com.typesafe:config:1.4.0")
   implementation("org.slf4j:slf4j-api:1.7.30")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.3")
 
   annotationProcessor("org.projectlombok:lombok:1.18.12")

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -89,10 +89,10 @@ dependencies {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
     }
     runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1070799")
     }
     runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1070799")
     }
   }
 }

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -84,15 +84,12 @@ dependencies {
   testFixturesAnnotationProcessor("org.projectlombok:lombok:1.18.12")
   testFixturesCompileOnly("org.projectlombok:lombok:1.18.12")
 
+  runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")
+  runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
+  
   constraints {
     implementation("com.google.guava:guava:30.1-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-    runtimeOnly("io.netty:netty-codec-http2:4.1.53.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.53.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
     }
   }
 }

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -84,12 +84,15 @@ dependencies {
   testFixturesAnnotationProcessor("org.projectlombok:lombok:1.18.12")
   testFixturesCompileOnly("org.projectlombok:lombok:1.18.12")
 
-  runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")
-  runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
-  
   constraints {
     implementation("com.google.guava:guava:30.1-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
+    }
+    runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+    }
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
     }
   }
 }


### PR DESCRIPTION
Updates doc-store version to include postgres impl of exists, not-exists, and NEQ filters

- hypertrace/document-store#35
- hypertrace/document-store#33