### PR TITLE
fix: publish test results other than codecov only on non-forked PR

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
-        if: always()
+        if: github.event_name == 'push'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ./**/build/test-results/**/*.xml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ./**/build/test-results/**/*.xml


### PR DESCRIPTION
## Description
- This test results we publish on every commit and PR are helpful but it fails on non-member PR because it requires access to secrets i.e. GitHub Token in this case as we can see here: https://github.com/hypertrace/document-store/runs/1901754228?check_suite_focus=true
- This PR changes trigger for that particular step to run only on non-forked PRs so it will give us data but at the same time won't block PRs from community. 


### Testing
tested this on my own fork: https://github.com/JBAhire/document-store/runs/1933950757?check_suite_focus=true

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

