### PR TITLE
Expose creation and update timestamp in getAllConfigs API

### DIFF
--- a/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
+++ b/config-service-api/src/main/proto/org/hypertrace/config/service/v1/config_service.proto
@@ -68,7 +68,7 @@ message GetAllConfigsRequest {
 }
 
 message GetAllConfigsResponse {
-  // list of config values along with the associated contexts
+  // list of config values along with the associated contexts, sorted in the ascending order of their creation time
   repeated ContextSpecificConfig context_specific_configs = 1;
 }
 
@@ -78,6 +78,12 @@ message ContextSpecificConfig {
 
   // config value which applies to the above context
   google.protobuf.Value config = 2;
+
+  // timestamp (in milliseconds since epoch) at which this config was created
+  int64 creation_timestamp = 3;
+
+  // timestamp (in milliseconds since epoch) at which this config was last updated
+  int64 update_timestamp = 4;
 }
 
 message DeleteConfigRequest {

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
@@ -57,11 +57,12 @@ public class ConfigServiceGrpcImpl extends ConfigServiceGrpc.ConfigServiceImplBa
   public void getConfig(GetConfigRequest request,
       StreamObserver<GetConfigResponse> responseObserver) {
     try {
-      Value config = configStore.getConfig(getConfigResource(request));
+      Value config = configStore.getConfig(getConfigResource(request)).getConfig();
 
       // get the configs for the contexts mentioned in the request and merge them in the specified order
       for (String context : request.getContextsList()) {
-        Value contextSpecificConfig = configStore.getConfig(getConfigResource(request, context));
+        Value contextSpecificConfig = configStore.getConfig(getConfigResource(request, context))
+            .getConfig();
         config = merge(config, contextSpecificConfig);
       }
 

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceUtils.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceUtils.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
 
 /**
  * This class contains utility methods.
@@ -83,5 +84,10 @@ public class ConfigServiceUtils {
 
   public static Value emptyValue() {
     return EMPTY_VALUE;
+  }
+
+  public static ContextSpecificConfig emptyConfig(String context) {
+    return ContextSpecificConfig.newBuilder().setConfig(EMPTY_VALUE).setContext(context)
+        .setCreationTimestamp(0).setUpdateTimestamp(0).build();
   }
 }

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocument.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocument.java
@@ -38,6 +38,8 @@ public class ConfigDocument implements Document {
   public static final String VERSION_FIELD_NAME = "configVersion";
   public static final String USER_ID_FIELD_NAME = "userId";
   public static final String CONFIG_FIELD_NAME = "config";
+  public static final String CREATION_TIMESTAMP_FIELD_NAME = "creationTimestamp";
+  public static final String UPDATE_TIMESTAMP_FIELD_NAME = "updateTimestamp";
 
   @JsonProperty(value = RESOURCE_FIELD_NAME)
   String resourceName;
@@ -62,6 +64,12 @@ public class ConfigDocument implements Document {
   @JsonProperty(value = CONFIG_FIELD_NAME)
   Value config;
 
+  @JsonProperty(value = CREATION_TIMESTAMP_FIELD_NAME)
+  long creationTimestamp;
+
+  @JsonProperty(value = UPDATE_TIMESTAMP_FIELD_NAME)
+  long updateTimestamp;
+
   @JsonCreator(mode = Mode.PROPERTIES)
   public ConfigDocument(@JsonProperty(RESOURCE_FIELD_NAME) String resourceName,
       @JsonProperty(RESOURCE_NAMESPACE_FIELD_NAME) String resourceNamespace,
@@ -69,7 +77,9 @@ public class ConfigDocument implements Document {
       @JsonProperty(CONTEXT_FIELD_NAME) String context,
       @JsonProperty(VERSION_FIELD_NAME) long configVersion,
       @JsonProperty(USER_ID_FIELD_NAME) String userId,
-      @JsonProperty(CONFIG_FIELD_NAME) Value config) {
+      @JsonProperty(CONFIG_FIELD_NAME) Value config,
+      @JsonProperty(CREATION_TIMESTAMP_FIELD_NAME) long creationTimestamp,
+      @JsonProperty(UPDATE_TIMESTAMP_FIELD_NAME) long updateTimestamp) {
     this.resourceName = resourceName;
     this.resourceNamespace = resourceNamespace;
     this.tenantId = tenantId;
@@ -77,6 +87,8 @@ public class ConfigDocument implements Document {
     this.configVersion = configVersion;
     this.userId = userId;
     this.config = config;
+    this.creationTimestamp = creationTimestamp;
+    this.updateTimestamp = updateTimestamp;
   }
 
   public static ConfigDocument fromJson(String json) throws IOException {

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigStore.java
@@ -37,11 +37,11 @@ public interface ConfigStore {
    * @param configResource
    * @return
    */
-  Value getConfig(ConfigResource configResource) throws IOException;
+  ContextSpecificConfig getConfig(ConfigResource configResource) throws IOException;
 
   /**
    * Get all the configs with the latest version(along with the context to which it applies) for the
-   * specified parameters.
+   * specified parameters, sorted in the ascending order of their creation time.
    *
    * @param resourceName
    * @param resourceNamespace

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
@@ -53,8 +53,6 @@ class ConfigServiceGrpcImplTest {
     ConfigStore configStore = mock(ConfigStore.class);
     when(configStore.writeConfig(any(ConfigResource.class), anyString(), any(Value.class)))
         .thenReturn(10L);
-    when(configStore.getConfig(eq(configResourceWithoutContext))).thenReturn(emptyValue(), config1);
-    when(configStore.getConfig(eq(configResourceWithContext))).thenReturn(emptyValue());
 
     ConfigServiceGrpcImpl configServiceGrpc = new ConfigServiceGrpcImpl(configStore);
 
@@ -86,8 +84,10 @@ class ConfigServiceGrpcImplTest {
   @Test
   void getConfig() throws IOException {
     ConfigStore configStore = mock(ConfigStore.class);
-    when(configStore.getConfig(eq(configResourceWithoutContext))).thenReturn(config1);
-    when(configStore.getConfig(eq(configResourceWithContext))).thenReturn(config2);
+    when(configStore.getConfig(eq(configResourceWithoutContext))).thenReturn(
+        ContextSpecificConfig.newBuilder().setConfig(config1).setContext(DEFAULT_CONTEXT).build());
+    when(configStore.getConfig(eq(configResourceWithContext))).thenReturn(
+        ContextSpecificConfig.newBuilder().setConfig(config2).setContext(CONTEXT1).build());
     ConfigServiceGrpcImpl configServiceGrpc = new ConfigServiceGrpcImpl(configStore);
     StreamObserver<GetConfigResponse> responseObserver = mock(StreamObserver.class);
 

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/ConfigDocumentTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/ConfigDocumentTest.java
@@ -1,0 +1,43 @@
+package org.hypertrace.config.service.store;
+
+import static org.hypertrace.config.service.ConfigServiceUtils.DEFAULT_CONTEXT;
+import static org.hypertrace.config.service.TestUtils.RESOURCE_NAME;
+import static org.hypertrace.config.service.TestUtils.RESOURCE_NAMESPACE;
+import static org.hypertrace.config.service.TestUtils.TENANT_ID;
+import static org.hypertrace.config.service.TestUtils.getConfig1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ConfigDocumentTest {
+
+  @Test
+  void convertToAndFromJson() throws IOException {
+    long timestamp = System.currentTimeMillis();
+    ConfigDocument configDocument = new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
+        TENANT_ID, DEFAULT_CONTEXT, 15, "user1", getConfig1(), timestamp, timestamp);
+    assertEquals(configDocument, ConfigDocument.fromJson(configDocument.toJson()));
+  }
+
+  @Test
+  @DisplayName("Test backward compatibility using a json string without creation and update timestamps")
+  void convertJsonStringWithoutTimestamp() throws IOException {
+    String jsonString = Resources
+        .toString(Resources.getResource("config1.json"), Charset.defaultCharset());
+    ConfigDocument configDocument = ConfigDocument.fromJson(jsonString);
+
+    assertEquals("config1", configDocument.getResourceName());
+    assertEquals("namespace1", configDocument.getResourceNamespace());
+    assertEquals("tenant1", configDocument.getTenantId());
+    assertEquals("DEFAULT-CONTEXT", configDocument.getContext());
+    assertEquals(1, configDocument.getConfigVersion());
+    assertEquals(getConfig1(), configDocument.getConfig());
+    assertEquals(0, configDocument.getCreationTimestamp());
+    assertEquals(0, configDocument.getUpdateTimestamp());
+  }
+
+}

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
@@ -42,6 +42,9 @@ class DocumentConfigStoreTest {
 
   private static final long CONFIG_VERSION = 5;
   private static final String USER_ID = "user1";
+  private static final long TIMESTAMP1 = 100L;
+  private static final long TIMESTAMP2 = 200L;
+  private static final long TIMESTAMP3 = 300L;
   private static DocumentConfigStore configStore = new DocumentConfigStore();
   private static Value config1 = getConfig1();
   private static Value config2 = getConfig2();
@@ -63,8 +66,10 @@ class DocumentConfigStoreTest {
   @Test
   void writeConfig() throws IOException {
     List<Document> documentList = Collections
-        .singletonList(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1));
-    when(collection.search(any(Query.class))).thenReturn(documentList.iterator());
+        .singletonList(
+            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1, TIMESTAMP1, TIMESTAMP2));
+    when(collection.search(any(Query.class)))
+        .thenReturn(documentList.iterator(), documentList.iterator());
 
     configStore.writeConfig(configResource, USER_ID, config1);
 
@@ -76,42 +81,51 @@ class DocumentConfigStoreTest {
     Document document = documentCaptor.getValue();
     long newVersion = CONFIG_VERSION + 1;
     assertEquals(new ConfigDocumentKey(configResource, newVersion), key);
-    assertEquals(getConfigDocument(DEFAULT_CONTEXT, newVersion, config1), document);
+    assertEquals(getConfigDocument(DEFAULT_CONTEXT, newVersion, config1, TIMESTAMP1,
+        ((ConfigDocument) document).getUpdateTimestamp()), document);
   }
 
   @Test
   void getConfig() throws IOException {
     List<Document> documentList = Collections
-        .singletonList(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1));
+        .singletonList(
+            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1, TIMESTAMP1, TIMESTAMP2));
     when(collection.search(any(Query.class)))
         .thenReturn(documentList.iterator(), documentList.iterator());
 
-    Value config = configStore.getConfig(configResource);
-    assertEquals(config1, config);
+    ContextSpecificConfig expectedConfig = ContextSpecificConfig.newBuilder().setConfig(config1)
+        .setContext(DEFAULT_CONTEXT).setCreationTimestamp(TIMESTAMP1).setUpdateTimestamp(TIMESTAMP2)
+        .build();
+    ContextSpecificConfig actualConfig = configStore.getConfig(configResource);
+    assertEquals(expectedConfig, actualConfig);
   }
 
   @Test
   void getAllConfigs() throws IOException {
     List<Document> documentList = List
-        .of(getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1),
-            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION - 1, config2),
-            getConfigDocument(CONTEXT1, 1L, config2));
+        .of(getConfigDocument(CONTEXT1, 1L, config2, TIMESTAMP3, TIMESTAMP3),
+            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION, config1, TIMESTAMP1, TIMESTAMP2),
+            getConfigDocument(DEFAULT_CONTEXT, CONFIG_VERSION - 1, config2, TIMESTAMP1,
+                TIMESTAMP1));
     when(collection.search(any(Query.class))).thenReturn(documentList.iterator());
 
     List<ContextSpecificConfig> contextSpecificConfigList = configStore
         .getAllConfigs(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_ID);
     assertEquals(2, contextSpecificConfigList.size());
     assertEquals(
-        ContextSpecificConfig.newBuilder().setContext(DEFAULT_CONTEXT).setConfig(config1).build(),
+        ContextSpecificConfig.newBuilder().setContext(DEFAULT_CONTEXT).setConfig(config1)
+            .setCreationTimestamp(TIMESTAMP1).setUpdateTimestamp(TIMESTAMP2).build(),
         contextSpecificConfigList.get(0));
     assertEquals(
-        ContextSpecificConfig.newBuilder().setContext(CONTEXT1).setConfig(config2).build(),
+        ContextSpecificConfig.newBuilder().setContext(CONTEXT1).setConfig(config2)
+            .setCreationTimestamp(TIMESTAMP3).setUpdateTimestamp(TIMESTAMP3).build(),
         contextSpecificConfigList.get(1));
   }
 
-  private static Document getConfigDocument(String context, long version, Value config) {
+  private static Document getConfigDocument(String context, long version, Value config,
+      long creationTimestamp, long updateTimestamp) {
     return new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
-        TENANT_ID, context, version, USER_ID, config);
+        TENANT_ID, context, version, USER_ID, config, creationTimestamp, updateTimestamp);
   }
 
   public static class MockDatastore implements Datastore {

--- a/config-service-impl/src/test/resources/config1.json
+++ b/config-service-impl/src/test/resources/config1.json
@@ -1,0 +1,21 @@
+{
+  "_id" : "config1:namespace1:tenant1:DEFAULT-CONTEXT:1",
+  "config" : {
+    "k1" : 10,
+    "k2" : "v2",
+    "k3" : [
+      {
+        "k31" : "v31"
+      },
+      {
+        "k32" : "v32"
+      }
+    ]
+  },
+  "configVersion" : 1,
+  "context" : "DEFAULT-CONTEXT",
+  "resourceName" : "config1",
+  "resourceNamespace" : "namespace1",
+  "tenantId" : "tenant1",
+  "userId" : ""
+}

--- a/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
+++ b/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
@@ -126,21 +126,33 @@ public class ConfigServiceIntegrationTest {
 
   @Test
   public void testGetAllConfigs() {
-    // upsert config with default or no context
-    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.empty(), config1);
+    // upsert config with context1
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_1), config1);
 
-    // upsert config with context
-    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_1), config2);
+    // upsert config with context2
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_2), config2);
 
+    // verify getAllConfigs
     List<ContextSpecificConfig> contextSpecificConfigList = getAllConfigs(RESOURCE_NAME,
         RESOURCE_NAMESPACE, TENANT_1).getContextSpecificConfigsList();
     assertEquals(2, contextSpecificConfigList.size());
-    assertEquals(
-        ContextSpecificConfig.newBuilder().setContext(DEFAULT_CONTEXT).setConfig(config1).build(),
-        contextSpecificConfigList.get(0));
-    assertEquals(
-        ContextSpecificConfig.newBuilder().setContext(CONTEXT_1).setConfig(config2).build(),
-        contextSpecificConfigList.get(1));
+    assertEquals(config1, contextSpecificConfigList.get(0).getConfig());
+    assertEquals(CONTEXT_1, contextSpecificConfigList.get(0).getContext());
+    assertEquals(config2, contextSpecificConfigList.get(1).getConfig());
+    assertEquals(CONTEXT_2, contextSpecificConfigList.get(1).getContext());
+
+    // delete first config and upsert it again so that its creation timestamp is greater than second config
+    deleteConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, CONTEXT_1);
+    upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_1, Optional.of(CONTEXT_1), config1);
+
+    // verify getAllConfigs - order should be reversed this time
+    contextSpecificConfigList = getAllConfigs(RESOURCE_NAME,
+        RESOURCE_NAMESPACE, TENANT_1).getContextSpecificConfigsList();
+    assertEquals(2, contextSpecificConfigList.size());
+    assertEquals(config2, contextSpecificConfigList.get(0).getConfig());
+    assertEquals(CONTEXT_2, contextSpecificConfigList.get(0).getContext());
+    assertEquals(config1, contextSpecificConfigList.get(1).getConfig());
+    assertEquals(CONTEXT_1, contextSpecificConfigList.get(1).getContext());
   }
 
   @Test


### PR DESCRIPTION
## Description
Addresses https://github.com/hypertrace/config-service/issues/25
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Unit tests and integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
