### PR TITLE
Fixes #16 : Handle null values gracefully

### DIFF
--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocument.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocument.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.config.service.ConfigServiceUtils;
 import org.hypertrace.core.documentstore.Document;
 
 import java.io.IOException;
@@ -123,6 +124,11 @@ public class ConfigDocument implements Document {
       Value.Builder valueBuilder = Value.newBuilder();
       JsonFormat.parser().merge(jsonString, valueBuilder);
       return valueBuilder.build();
+    }
+
+    @Override
+    public Value getNullValue(DeserializationContext ctxt) {
+      return ConfigServiceUtils.emptyValue();
     }
   }
 }

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/ConfigDocumentTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/ConfigDocumentTest.java
@@ -8,6 +8,9 @@ import static org.hypertrace.config.service.TestUtils.getConfig1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.io.Resources;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +23,15 @@ public class ConfigDocumentTest {
     long timestamp = System.currentTimeMillis();
     ConfigDocument configDocument = new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
         TENANT_ID, DEFAULT_CONTEXT, 15, "user1", getConfig1(), timestamp, timestamp);
+    assertEquals(configDocument, ConfigDocument.fromJson(configDocument.toJson()));
+  }
+
+  @Test
+  void convertDocumentContainingNullValue() throws IOException {
+    long timestamp = System.currentTimeMillis();
+    Value nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+    ConfigDocument configDocument = new ConfigDocument(RESOURCE_NAME, RESOURCE_NAMESPACE,
+        TENANT_ID, DEFAULT_CONTEXT, 15, "user1", nullValue, timestamp, timestamp);
     assertEquals(configDocument, ConfigDocument.fromJson(configDocument.toJson()));
   }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/hypertrace/config-service/issues/16

Serialization of `NULL_VALUE` (`Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()`) yields the string - "null", which when deserialized was previously returning the Value as `null`. Although, we handle `null` also using the [isNull() method](https://github.com/hypertrace/config-service/blob/main/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceUtils.java#L73) (which is why it wasn't affecting the client), we also log an error saying that it is unexpected because ideally, we shouldn't be working with `null` - instead we should be using the null placeholder - `NULL_VALUE`.

So, this change tells the `JsonDeserializer` to use the null placeholder (`NULL_VALUE`) on encountering the string - "null", which ensures that we never get `null` config on deserialization.

### Testing
Added unit test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Any dependent changes have been merged and published in downstream modules