### PR TITLE
fix: update mock generic config service

### DIFF
--- a/config-proto-converter/build.gradle.kts
+++ b/config-proto-converter/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.36.1")
+  api("io.grpc:grpc-protobuf:1.37.0")
   implementation("com.google.protobuf:protobuf-java-util:3.15.7")
 }

--- a/config-service-api/build.gradle.kts
+++ b/config-service-api/build.gradle.kts
@@ -23,7 +23,7 @@ protobuf {
     // the identifier, which can be referred to in the "plugins"
     // container of the "generateProtoTasks" closure.
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.36.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.37.0"
     }
 
     if (generateLocalGoGrpcFiles) {
@@ -62,16 +62,16 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.36.1")
-  api("io.grpc:grpc-stub:1.36.1")
+  api("io.grpc:grpc-protobuf:1.37.0")
+  api("io.grpc:grpc-stub:1.37.0")
   api("javax.annotation:javax.annotation-api:1.3.2")
 
-  testFixturesApi("io.grpc:grpc-api:1.36.1")
+  testFixturesApi("io.grpc:grpc-api:1.37.0")
   testFixturesApi(project(":config-service-api"))
-  testFixturesImplementation("io.grpc:grpc-stub:1.36.1")
-  testFixturesImplementation("io.grpc:grpc-core:1.36.1")
+  testFixturesImplementation("io.grpc:grpc-stub:1.37.0")
+  testFixturesImplementation("io.grpc:grpc-core:1.37.0")
   testFixturesImplementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
-  testFixturesImplementation("org.mockito:mockito-core:3.8.0")
+  testFixturesImplementation("org.mockito:mockito-core:3.9.0")
   testFixturesImplementation("com.google.guava:guava:30.1.1-jre")
   testFixturesAnnotationProcessor("org.projectlombok:lombok:1.18.20")
   testFixturesCompileOnly("org.projectlombok:lombok:1.18.20")

--- a/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
+++ b/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
@@ -62,6 +62,11 @@ public class MockGenericConfigService {
       Mockito.mock(
           ConfigServiceImplBase.class,
           invocation -> { // Error if unmocked called so we don't hang waiting for streamobserver
+            if (invocation
+                .getMethod()
+                .equals(ConfigServiceImplBase.class.getMethod("bindService"))) {
+              return invocation.callRealMethod();
+            }
             throw new UnsupportedOperationException("Unmocked method invoked");
           });
 

--- a/config-service-impl/build.gradle.kts
+++ b/config-service-impl/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   compileOnly("org.projectlombok:lombok:1.18.20")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("org.mockito:mockito-core:3.8.0")
+  testImplementation("org.mockito:mockito-core:3.9.0")
   testImplementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
 }
 

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.30")
 
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1")
-  runtimeOnly("io.grpc:grpc-netty:1.36.1")
+  runtimeOnly("io.grpc:grpc-netty:1.37.0")
 
   // Integration test dependencies
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/spaces-config-service-api/build.gradle.kts
+++ b/spaces-config-service-api/build.gradle.kts
@@ -17,7 +17,7 @@ protobuf {
   }
   plugins {
     id("grpc") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.36.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.37.0"
     }
   }
   generateProtoTasks {
@@ -30,14 +30,9 @@ protobuf {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.36.1")
-  api("io.grpc:grpc-stub:1.36.1")
+  api("io.grpc:grpc-protobuf:1.37.0")
+  api("io.grpc:grpc-stub:1.37.0")
   api("javax.annotation:javax.annotation-api:1.3.2")
-  constraints {
-    implementation("com.google.guava:guava:30.1-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-  }
 }
 
 sourceSets {

--- a/spaces-config-service-impl/build.gradle.kts
+++ b/spaces-config-service-impl/build.gradle.kts
@@ -16,8 +16,8 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("org.mockito:mockito-core:3.8.0")
-  testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
+  testImplementation("org.mockito:mockito-core:3.9.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:3.9.0")
   testImplementation(testFixtures(project(":config-service-api")))
 }
 


### PR DESCRIPTION
## Description
When using inline mocks, we want to use the real bind service in our mock config service. Also bumped some services.
