### PR TITLE
Added default system tags

### DIFF
--- a/tags-config-service-impl/src/main/java/org/hypertrace/tag/config/service/TagConfigServiceImpl.java
+++ b/tags-config-service-impl/src/main/java/org/hypertrace/tag/config/service/TagConfigServiceImpl.java
@@ -1,9 +1,14 @@
 package org.hypertrace.tag.config.service;
 
+import com.typesafe.config.Config;
 import io.grpc.Channel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.tag.config.service.v1.CreateTag;
@@ -23,9 +28,20 @@ import org.hypertrace.tag.config.service.v1.UpdateTagResponse;
 @Slf4j
 public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceImplBase {
   private final ConfigServiceCoordinator configServiceCoordinator;
+  private final List<String> SYSTEM_TAGS;
+  private final List<String> SYSTEM_TAG_PATHS =
+      Arrays.asList(
+          "tag.config.service.CRITICAL",
+          "tag.config.service.SENSITIVE",
+          "tag.config.service.EXTERNAL",
+          "tag.config.service.SENTRY");
 
-  public TagConfigServiceImpl(Channel configChannel) {
+  public TagConfigServiceImpl(Channel configChannel, Config config) {
     configServiceCoordinator = new ConfigServiceCoordinatorImpl(configChannel);
+    SYSTEM_TAGS =
+        SYSTEM_TAG_PATHS.stream()
+            .map(tagPath -> config.getString(tagPath))
+            .collect(Collectors.toList());
   }
 
   @Override
@@ -34,6 +50,11 @@ public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceI
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       CreateTag createTag = request.getTag();
+      if (SYSTEM_TAGS.contains(createTag.getKey())) {
+        // Creating a tag with a name that clashes with one of system tags name
+        responseObserver.onError(new StatusRuntimeException(Status.ALREADY_EXISTS));
+        return;
+      }
       Tag tag =
           Tag.newBuilder().setId(UUID.randomUUID().toString()).setKey(createTag.getKey()).build();
       Tag createdTag = configServiceCoordinator.upsertTag(requestContext, tag);
@@ -46,10 +67,15 @@ public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceI
 
   @Override
   public void getTag(GetTagRequest request, StreamObserver<GetTagResponse> responseObserver) {
+    String tagId = request.getId();
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
-      String tagId = request.getId();
-      Tag tag = configServiceCoordinator.getTag(requestContext, tagId);
+      Tag tag;
+      if (SYSTEM_TAGS.contains(tagId)) {
+        tag = Tag.newBuilder().setId(tagId).setKey(tagId).build();
+      } else {
+        tag = configServiceCoordinator.getTag(requestContext, tagId);
+      }
       responseObserver.onNext(GetTagResponse.newBuilder().setTag(tag).build());
       responseObserver.onCompleted();
     } catch (Exception e) {
@@ -61,6 +87,11 @@ public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceI
   public void getTags(GetTagsRequest request, StreamObserver<GetTagsResponse> responseObserver) {
     RequestContext requestContext = RequestContext.CURRENT.get();
     List<Tag> tagList = configServiceCoordinator.getAllTags(requestContext);
+    List<Tag> systemTagsList =
+        SYSTEM_TAGS.stream()
+            .map(key -> Tag.newBuilder().setId(key).setKey(key).build())
+            .collect(Collectors.toList());
+    tagList.addAll(systemTagsList);
     responseObserver.onNext(GetTagsResponse.newBuilder().addAllTags(tagList).build());
     responseObserver.onCompleted();
   }
@@ -68,11 +99,21 @@ public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceI
   @Override
   public void updateTag(
       UpdateTagRequest request, StreamObserver<UpdateTagResponse> responseObserver) {
+    Tag updatedTagInReq = request.getTag();
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
-      Tag updatedTagInReq = request.getTag();
+      if (SYSTEM_TAGS.contains(updatedTagInReq.getId())) {
+        // Updating a system tag will error
+        responseObserver.onError(new StatusRuntimeException(Status.PERMISSION_DENIED));
+        return;
+      }
       configServiceCoordinator.getTag(requestContext, updatedTagInReq.getId());
-      Tag updatedTagInRes = configServiceCoordinator.upsertTag(requestContext, request.getTag());
+      if (SYSTEM_TAGS.contains(updatedTagInReq.getKey())) {
+        // Updating the name of some tag to name of some system tag will error
+        responseObserver.onError(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+        return;
+      }
+      Tag updatedTagInRes = configServiceCoordinator.upsertTag(requestContext, updatedTagInReq);
       responseObserver.onNext(UpdateTagResponse.newBuilder().setTag(updatedTagInRes).build());
       responseObserver.onCompleted();
     } catch (Exception e) {
@@ -86,6 +127,11 @@ public class TagConfigServiceImpl extends TagConfigServiceGrpc.TagConfigServiceI
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       String tagId = request.getId();
+      if (SYSTEM_TAGS.contains(tagId)) {
+        // Deleting a system tag
+        responseObserver.onError(new StatusRuntimeException(Status.PERMISSION_DENIED));
+        return;
+      }
       configServiceCoordinator.getTag(requestContext, tagId);
       configServiceCoordinator.deleteTag(requestContext, tagId);
       responseObserver.onNext(DeleteTagResponse.newBuilder().build());

--- a/tags-config-service-impl/src/test/java/org/hypertrace/tag/config/service/TagConfigServiceImplTest.java
+++ b/tags-config-service-impl/src/test/java/org/hypertrace/tag/config/service/TagConfigServiceImplTest.java
@@ -2,9 +2,14 @@ package org.hypertrace.tag.config.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import io.grpc.Channel;
+import io.grpc.Status;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hypertrace.config.service.test.MockGenericConfigService;
@@ -26,7 +31,9 @@ import org.junit.jupiter.api.Test;
 
 public final class TagConfigServiceImplTest {
   TagConfigServiceBlockingStub tagConfigStub;
+  Config config;
   MockGenericConfigService mockGenericConfigService;
+  List<String> systemTags = Arrays.asList("Critical", "Sensitive", "External", "Sentry");
   List<CreateTag> createTagsList =
       Arrays.asList(0, 1, 2, 3, 4).stream()
           .map(id -> CreateTag.newBuilder().setKey("Tag-" + id).build())
@@ -36,8 +43,22 @@ public final class TagConfigServiceImplTest {
   void setUp() {
     mockGenericConfigService =
         new MockGenericConfigService().mockUpsert().mockGet().mockGetAll().mockDelete();
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put(
+        "tag.config.service",
+        Map.of(
+            "CRITICAL",
+            systemTags.get(0),
+            "SENSITIVE",
+            systemTags.get(1),
+            "EXTERNAL",
+            systemTags.get(2),
+            "SENTRY",
+            systemTags.get(3)));
+    config = ConfigFactory.parseMap(configMap);
     Channel channel = mockGenericConfigService.channel();
-    mockGenericConfigService.addService(new TagConfigServiceImpl(channel)).start();
+    mockGenericConfigService.addService(new TagConfigServiceImpl(channel, config)).start();
+
     tagConfigStub = TagConfigServiceGrpc.newBlockingStub(channel);
   }
 
@@ -68,6 +89,19 @@ public final class TagConfigServiceImplTest {
   }
 
   @Test
+  void test_system_createTag() {
+    for (String key : systemTags) {
+      CreateTagRequest createTagRequest =
+          CreateTagRequest.newBuilder().setTag(CreateTag.newBuilder().setKey(key).build()).build();
+      try {
+        tagConfigStub.createTag(createTagRequest);
+      } catch (Exception e) {
+        assertEquals(Status.ALREADY_EXISTS, Status.fromThrowable(e));
+      }
+    }
+  }
+
+  @Test
   void test_getTag() {
     List<Tag> createdTagsList = createTags();
     // Querying each tag one by one for the created or inserted tags in the previous step
@@ -94,8 +128,23 @@ public final class TagConfigServiceImplTest {
   }
 
   @Test
+  void test_system_getTag() {
+    for (String key : systemTags) {
+      GetTagRequest getTagRequest = GetTagRequest.newBuilder().setId(key).build();
+      GetTagResponse getTagResponse = tagConfigStub.getTag(getTagRequest);
+      assertEquals(key, getTagResponse.getTag().getId());
+      assertEquals(key, getTagResponse.getTag().getKey());
+    }
+  }
+
+  @Test
   void test_getTags() {
     List<Tag> createdTagsList = createTags();
+    List<Tag> systemTagList =
+        systemTags.stream()
+            .map(key -> Tag.newBuilder().setId(key).setKey(key).build())
+            .collect(Collectors.toList());
+    createdTagsList.addAll(systemTagList);
     // Querying for all the tags at once for the created or inserted tags in the previous step
     List<Tag> getTags = tagConfigStub.getTags(GetTagsRequest.newBuilder().build()).getTagsList();
     assertEquals(Set.copyOf(createdTagsList), Set.copyOf(getTags));
@@ -135,6 +184,33 @@ public final class TagConfigServiceImplTest {
   }
 
   @Test
+  void test_system_updateTag() {
+    List<Tag> createdTagsList = createTags();
+    for (String id : systemTags) {
+      UpdateTagRequest updateTagRequest =
+          UpdateTagRequest.newBuilder()
+              .setTag(Tag.newBuilder().setId(id).setKey("1").build())
+              .build();
+      try {
+        tagConfigStub.updateTag(updateTagRequest);
+      } catch (Exception e) {
+        assertEquals(Status.PERMISSION_DENIED, Status.fromThrowable(e));
+      }
+    }
+    for (String key : systemTags) {
+      UpdateTagRequest updateTagRequest =
+          UpdateTagRequest.newBuilder()
+              .setTag(Tag.newBuilder().setId(createdTagsList.get(0).getId()).setKey(key).build())
+              .build();
+      try {
+        tagConfigStub.updateTag(updateTagRequest);
+      } catch (Exception e) {
+        assertEquals(Status.INVALID_ARGUMENT, Status.fromThrowable(e));
+      }
+    }
+  }
+
+  @Test
   void test_deleteTag() {
     List<Tag> createdTagsList = createTags();
     // Deleting a tag that does not exist
@@ -156,6 +232,22 @@ public final class TagConfigServiceImplTest {
               assertEquals(false, allTags.contains(tag));
             });
     List<Tag> allTags = tagConfigStub.getTags(GetTagsRequest.newBuilder().build()).getTagsList();
-    assertEquals(true, allTags.isEmpty());
+    List<Tag> systemTagsList =
+        systemTags.stream()
+            .map(key -> Tag.newBuilder().setId(key).setKey(key).build())
+            .collect(Collectors.toList());
+    assertEquals(systemTagsList, allTags);
+  }
+
+  @Test
+  void test_system_deleteTag() {
+    for (String key : systemTags) {
+      DeleteTagRequest deleteTagRequest = DeleteTagRequest.newBuilder().setId(key).build();
+      try {
+        tagConfigStub.deleteTag(deleteTagRequest);
+      } catch (Exception e) {
+        assertEquals(Status.PERMISSION_DENIED, Status.fromThrowable(e));
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
**Added the functionality supporting default system tags as from application.conf**
This will make sure that no other tags with the same names as system tags are created. 
Also it does not allow users to update or delete default system tags or make some other tag as system tag.
Implemented unit tests to verify everything is correct.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Implemented Unit tests and verified locally.

### Checklist:
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
https://traceableai.atlassian.net/browse/ENG-11179
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
