### PR TITLE
Adding functionality to enforce key uniqueness for labels

### DIFF
--- a/labels-config-service-impl/src/main/java/org/hypertrace/label/config/service/LabelsConfigServiceImpl.java
+++ b/labels-config-service-impl/src/main/java/org/hypertrace/label/config/service/LabelsConfigServiceImpl.java
@@ -91,8 +91,9 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
       CreateLabelRequest request, StreamObserver<CreateLabelResponse> responseObserver) {
     RequestContext requestContext = RequestContext.CURRENT.get();
     Lock labelsLock = this.stripedLabelsLock.get(requestContext.getTenantId());
+    boolean lockAcquired = false;
     try {
-      boolean lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
+      lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
       if (lockAcquired) {
         CreateLabel createLabel = request.getLabel();
         if (systemLabelsKeyLabelMap.containsKey(createLabel.getKey())
@@ -115,7 +116,7 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
     } catch (Exception e) {
       responseObserver.onError(e);
     } finally {
-      labelsLock.unlock();
+      if (lockAcquired) labelsLock.unlock();
     }
   }
 
@@ -153,8 +154,9 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
     Label updatedLabelInReq = request.getLabel();
     RequestContext requestContext = RequestContext.CURRENT.get();
     Lock labelsLock = this.stripedLabelsLock.get(requestContext.getTenantId());
+    boolean lockAcquired = false;
     try {
-      boolean lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
+      lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
       if (lockAcquired) {
         if (systemLabelsIdLabelMap.containsKey(updatedLabelInReq.getId())
             || systemLabelsKeyLabelMap.containsKey(updatedLabelInReq.getKey())) {
@@ -178,7 +180,7 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
     } catch (Exception e) {
       responseObserver.onError(e);
     } finally {
-      labelsLock.unlock();
+      if (lockAcquired) labelsLock.unlock();
     }
   }
 
@@ -188,8 +190,9 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
     RequestContext requestContext = RequestContext.CURRENT.get();
     Lock labelsLock = this.stripedLabelsLock.get(requestContext.getTenantId());
     labelsLock.lock();
+    boolean lockAcquired = false;
     try {
-      boolean lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
+      lockAcquired = labelsLock.tryLock(WAIT_TIME.getSeconds(), TimeUnit.SECONDS);
       if (lockAcquired) {
         String labelId = request.getId();
         if (systemLabelsIdLabelMap.containsKey(labelId)) {
@@ -207,7 +210,7 @@ public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfi
     } catch (Exception e) {
       responseObserver.onError(e);
     } finally {
-      labelsLock.unlock();
+      if (lockAcquired) labelsLock.unlock();
     }
   }
 

--- a/labels-config-service-impl/src/main/java/org/hypertrace/label/config/service/LabelsConfigServiceImpl.java
+++ b/labels-config-service-impl/src/main/java/org/hypertrace/label/config/service/LabelsConfigServiceImpl.java
@@ -37,15 +37,15 @@ import org.hypertrace.label.config.service.v1.UpdateLabelResponse;
 
 @Slf4j
 public class LabelsConfigServiceImpl extends LabelsConfigServiceGrpc.LabelsConfigServiceImplBase {
+  private static final Duration WAIT_TIME = Duration.newBuilder().setSeconds(5).build();
+  private static final String LABELS_CONFIG_SERVICE_CONFIG = "labels.config.service";
+  private static final String SYSTEM_LABELS = "system.labels";
+  private static final int LABEL_LOCK_STRIPE_COUNT = 1000;
   private final ConfigServiceCoordinator configServiceCoordinator;
-  private final String LABELS_CONFIG_SERVICE_CONFIG = "labels.config.service";
-  private final String SYSTEM_LABELS = "system.labels";
   private final List<Label> systemLabels;
   private final Map<String, Label> systemLabelsIdLabelMap;
   private final Map<String, Label> systemLabelsKeyLabelMap;
   private final Striped<Lock> stripedLabelsLock;
-  private static final int LABEL_LOCK_STRIPE_COUNT = 1000;
-  private static final Duration WAIT_TIME = Duration.newBuilder().setSeconds(5).build();
 
   public LabelsConfigServiceImpl(Channel configChannel, Config config) {
     stripedLabelsLock = Striped.lazyWeakLock(LABEL_LOCK_STRIPE_COUNT);

--- a/labels-config-service-impl/src/test/java/org/hypertrace/label/config/service/LabelsConfigServiceImplTest.java
+++ b/labels-config-service-impl/src/test/java/org/hypertrace/label/config/service/LabelsConfigServiceImplTest.java
@@ -87,6 +87,14 @@ public final class LabelsConfigServiceImplTest {
             .map(label -> CreateLabel.newBuilder().setKey(label.getKey()).build())
             .collect(Collectors.toList());
     assertEquals(createLabelsList, createdLabelsList);
+    Throwable exception =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> {
+              labelConfigStub.createLabel(
+                  CreateLabelRequest.newBuilder().setLabel(createLabelsList.get(0)).build());
+            });
+    assertEquals(Status.ALREADY_EXISTS, Status.fromThrowable(exception));
   }
 
   @Test
@@ -155,6 +163,20 @@ public final class LabelsConfigServiceImplTest {
   @Test
   void test_updateLabel() {
     List<Label> createdLabelsList = createLabels();
+    Throwable exception1 =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> {
+              labelConfigStub.updateLabel(
+                  UpdateLabelRequest.newBuilder()
+                      .setLabel(
+                          Label.newBuilder()
+                              .setId(createdLabelsList.get(1).getId())
+                              .setKey(createdLabelsList.get(0).getKey())
+                              .build())
+                      .build());
+            });
+    assertEquals(Status.ALREADY_EXISTS, Status.fromThrowable(exception1));
     // Updating the labels by appending the keys of labels with a "new"
     List<Label> updateLabelsList =
         createdLabelsList.stream()


### PR DESCRIPTION
## Description
**Enforcing Key uniqueness for labels:** Added support for checking duplicate keys while creating or updated labels. Added unit tests to verify correctness.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
