### PR TITLE
refactor: add object store abstractions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
 
 [bundles]
 grpc-api = ["grpc-stub", "grpc-protobuf", "javax-annotation"]

--- a/object-store/build.gradle.kts
+++ b/object-store/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  `java-library`
+  jacoco
+  id("org.hypertrace.jacoco-report-plugin")
+}
+
+dependencies {
+  api(projects.configServiceApi)
+  api(libs.hypertrace.grpcutils.context)
+
+  annotationProcessor(libs.lombok)
+  compileOnly(libs.lombok)
+
+  testImplementation(libs.junit.jupiter)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.junit)
+  testImplementation(libs.mockito.inline)
+  testImplementation(libs.protobuf.javautil)
+
+  testAnnotationProcessor(libs.lombok)
+  testCompileOnly(libs.lombok)
+}
+
+tasks.test {
+  useJUnitPlatform()
+}

--- a/object-store/src/main/java/org/hypertrace/config/objectstore/DefaultObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/DefaultObjectStore.java
@@ -1,0 +1,84 @@
+package org.hypertrace.config.objectstore;
+
+import com.google.protobuf.Value;
+import io.grpc.Status;
+import java.util.Optional;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+
+/**
+ * DefaultObjectStore is an abstraction over the grpc api for config implementations working with
+ * single object with no identifier - a pattern often used for a tenant-wide config.
+ *
+ * @param <T>
+ */
+public abstract class DefaultObjectStore<T> {
+  private final ConfigServiceBlockingStub configServiceBlockingStub;
+  private final String resourceNamespace;
+  private final String resourceName;
+
+  protected DefaultObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+  }
+
+  protected abstract Optional<T> buildObjectFromValue(Value value);
+
+  protected abstract Value buildValueFromObject(T object);
+
+  public Optional<T> getObject(RequestContext context) {
+    try {
+      Value value =
+          context.call(
+              () ->
+                  this.configServiceBlockingStub
+                      .getConfig(
+                          GetConfigRequest.newBuilder()
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .build())
+                      .getConfig());
+      T object = this.buildObjectFromValue(value).orElseThrow(Status.INTERNAL::asRuntimeException);
+      return Optional.of(object);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
+  }
+
+  public T upsertObject(RequestContext context, T object) {
+    Value upsertedValue =
+        context.call(
+            () ->
+                this.configServiceBlockingStub
+                    .upsertConfig(
+                        UpsertConfigRequest.newBuilder()
+                            .setResourceName(this.resourceName)
+                            .setResourceNamespace(this.resourceNamespace)
+                            .setConfig(this.buildValueFromObject(object))
+                            .build())
+                    .getConfig());
+
+    return this.buildObjectFromValue(upsertedValue)
+        .orElseThrow(Status.INTERNAL::asRuntimeException);
+  }
+
+  public void deleteObject(RequestContext context) {
+    context.call(
+        () ->
+            this.configServiceBlockingStub.deleteConfig(
+                DeleteConfigRequest.newBuilder()
+                    .setResourceName(this.resourceName)
+                    .setResourceNamespace(this.resourceNamespace)
+                    .build()));
+  }
+}

--- a/object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
@@ -1,0 +1,123 @@
+package org.hypertrace.config.objectstore;
+
+import com.google.protobuf.Value;
+import io.grpc.Status;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+
+/**
+ * IdentifiedObjectStore is an abstraction over the grpc api for config implementations working with
+ * multiple objects with unique identifiers
+ *
+ * @param <T>
+ */
+public abstract class IdentifiedObjectStore<T> {
+  private final ConfigServiceBlockingStub configServiceBlockingStub;
+  private final String resourceNamespace;
+  private final String resourceName;
+
+  protected IdentifiedObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+  }
+
+  protected abstract Optional<T> buildObjectFromValue(Value value);
+
+  protected abstract Value buildValueFromObject(T object);
+
+  protected abstract String getContextFromObject(T object);
+
+  protected List<T> orderFetchedObjects(List<T> objects) {
+    return objects;
+  }
+
+  public List<T> getAllObjects(RequestContext context) {
+    return context
+        .call(
+            () ->
+                this.configServiceBlockingStub.getAllConfigs(
+                    GetAllConfigsRequest.newBuilder()
+                        .setResourceName(this.resourceName)
+                        .setResourceNamespace(this.resourceNamespace)
+                        .build()))
+        .getContextSpecificConfigsList()
+        .stream()
+        .map(ContextSpecificConfig::getConfig)
+        .map(this::buildObjectFromValue)
+        .flatMap(Optional::stream)
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toUnmodifiableList(), this::orderFetchedObjects));
+  }
+
+  public Optional<T> getObject(RequestContext context, String id) {
+    try {
+      Value value =
+          context.call(
+              () ->
+                  this.configServiceBlockingStub
+                      .getConfig(
+                          GetConfigRequest.newBuilder()
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .addContexts(id)
+                              .build())
+                      .getConfig());
+      T object = this.buildObjectFromValue(value).orElseThrow(Status.INTERNAL::asRuntimeException);
+      return Optional.of(object);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
+  }
+
+  public T upsertObject(RequestContext context, T object) {
+    Value upsertedValue =
+        context.call(
+            () ->
+                this.configServiceBlockingStub
+                    .upsertConfig(
+                        UpsertConfigRequest.newBuilder()
+                            .setResourceName(this.resourceName)
+                            .setResourceNamespace(this.resourceNamespace)
+                            .setContext(this.getContextFromObject(object))
+                            .setConfig(this.buildValueFromObject(object))
+                            .build())
+                    .getConfig());
+
+    return this.buildObjectFromValue(upsertedValue)
+        .orElseThrow(Status.INTERNAL::asRuntimeException);
+  }
+
+  public void deleteObject(RequestContext context, String id) {
+    context.call(
+        () ->
+            this.configServiceBlockingStub.deleteConfig(
+                DeleteConfigRequest.newBuilder()
+                    .setResourceName(this.resourceName)
+                    .setResourceNamespace(this.resourceNamespace)
+                    .setContext(id)
+                    .build()));
+  }
+
+  public List<T> upsertObjects(RequestContext context, List<T> objects) {
+    // TODO push down a bulk upsert API
+    return objects.stream()
+        .map(object -> this.upsertObject(context, object))
+        .collect(Collectors.toUnmodifiableList());
+  }
+}

--- a/object-store/src/test/java/DefaultObjectStoreTest.java
+++ b/object-store/src/test/java/DefaultObjectStoreTest.java
@@ -1,0 +1,121 @@
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Value;
+import com.google.protobuf.util.Values;
+import io.grpc.Status;
+import java.util.Optional;
+import org.hypertrace.config.objectstore.DefaultObjectStore;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultObjectStoreTest {
+  private static final String TEST_RESOURCE_NAMESPACE = "test-namespace";
+  private static final String TEST_RESOURCE_NAME = "test-resource";
+
+  @Mock ConfigServiceBlockingStub mockStub;
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  RequestContext mockRequestContext;
+
+  DefaultObjectStore<TestObject> store;
+
+  @BeforeEach
+  void beforeEach() {
+    this.mockStub = mock(ConfigServiceBlockingStub.class);
+    this.store = new TestObjectStore(this.mockStub);
+  }
+
+  @Test
+  void generatesConfigReadRequestForGet() {
+    when(this.mockStub.getConfig(any()))
+        .thenReturn(GetConfigResponse.newBuilder().setConfig(Values.of("test")).build());
+
+    assertEquals(
+        Optional.of(new TestObject("test")), this.store.getObject(this.mockRequestContext));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+
+    when(this.mockStub.getConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.getObject(this.mockRequestContext));
+
+    verify(this.mockStub, times(2))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+  }
+
+  @Test
+  void generatesConfigDeleteRequest() {
+    assertDoesNotThrow(() -> this.store.deleteObject(mockRequestContext));
+
+    verify(this.mockStub)
+        .deleteConfig(
+            DeleteConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+  }
+
+  @Test
+  void generatesConfigUpsertRequest() {
+    when(this.mockStub.upsertConfig(any()))
+        .thenReturn(UpsertConfigResponse.newBuilder().setConfig(Values.of("updated")).build());
+    assertEquals(
+        new TestObject("updated"),
+        this.store.upsertObject(this.mockRequestContext, new TestObject("updated")));
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setConfig(Values.of("updated"))
+                .build());
+  }
+
+  @lombok.Value
+  private static class TestObject {
+    String name;
+  }
+
+  private static class TestObjectStore extends DefaultObjectStore<TestObject> {
+    private TestObjectStore(ConfigServiceBlockingStub stub) {
+      super(stub, TEST_RESOURCE_NAMESPACE, TEST_RESOURCE_NAME);
+    }
+
+    @Override
+    protected Optional<TestObject> buildObjectFromValue(Value value) {
+      return Optional.of(new TestObject(value.getStringValue()));
+    }
+
+    @Override
+    protected Value buildValueFromObject(TestObject object) {
+      return Values.of(object.getName());
+    }
+  }
+}

--- a/object-store/src/test/java/IdentifiedObjectStoreTest.java
+++ b/object-store/src/test/java/IdentifiedObjectStoreTest.java
@@ -1,0 +1,222 @@
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.Values;
+import io.grpc.Status;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.hypertrace.config.objectstore.IdentifiedObjectStore;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsRequest;
+import org.hypertrace.config.service.v1.GetAllConfigsResponse;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdentifiedObjectStoreTest {
+  private static final String TEST_RESOURCE_NAMESPACE = "test-namespace";
+  private static final String TEST_RESOURCE_NAME = "test-resource";
+
+  private static final TestObject OBJECT_1 = TestObject.builder().id("first-id").rank(1).build();
+
+  private static final TestObject OBJECT_2 = TestObject.builder().id("second-id").rank(2).build();
+
+  private static final Value OBJECT_1_AS_VALUE =
+      Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putFields("id", Values.of("first-id"))
+                  .putFields("rank", Values.of(1)))
+          .build();
+
+  private static final Value OBJECT_2_AS_VALUE =
+      Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putFields("id", Values.of("second-id"))
+                  .putFields("rank", Values.of(2)))
+          .build();
+
+  @Mock ConfigServiceBlockingStub mockStub;
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  RequestContext mockRequestContext;
+
+  IdentifiedObjectStore<TestObject> store;
+
+  @BeforeEach
+  void beforeEach() {
+    this.mockStub = mock(ConfigServiceBlockingStub.class);
+    this.store = new TestObjectStore(this.mockStub);
+  }
+
+  @Test
+  void generatesConfigReadRequestForGetAll() {
+    when(this.mockStub.getAllConfigs(any()))
+        .thenReturn(
+            GetAllConfigsResponse.newBuilder()
+                .addContextSpecificConfigs(
+                    ContextSpecificConfig.newBuilder().setConfig(OBJECT_2_AS_VALUE))
+                .addContextSpecificConfigs(
+                    ContextSpecificConfig.newBuilder().setConfig(OBJECT_1_AS_VALUE))
+                .build());
+    assertEquals(List.of(OBJECT_1, OBJECT_2), this.store.getAllObjects(this.mockRequestContext));
+
+    verify(this.mockStub)
+        .getAllConfigs(
+            GetAllConfigsRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+  }
+
+  @Test
+  void generatesConfigReadRequestForGet() {
+    when(this.mockStub.getConfig(any()))
+        .thenReturn(GetConfigResponse.newBuilder().setConfig(OBJECT_1_AS_VALUE).build());
+
+    assertEquals(Optional.of(OBJECT_1), this.store.getObject(this.mockRequestContext, "id"));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .addContexts("id")
+                .build());
+
+    when(this.mockStub.getConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.getObject(this.mockRequestContext, "second-id"));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .addContexts("second-id")
+                .build());
+  }
+
+  @Test
+  void generatesConfigDeleteRequest() {
+    assertDoesNotThrow(() -> this.store.deleteObject(mockRequestContext, "some-id"));
+
+    verify(this.mockStub)
+        .deleteConfig(
+            DeleteConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("some-id")
+                .build());
+  }
+
+  @Test
+  void generatesConfigUpsertRequest() {
+    when(this.mockStub.upsertConfig(any()))
+        .thenReturn(UpsertConfigResponse.newBuilder().setConfig(OBJECT_1_AS_VALUE).build());
+    assertEquals(OBJECT_1, this.store.upsertObject(this.mockRequestContext, OBJECT_1));
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("first-id")
+                .setConfig(OBJECT_1_AS_VALUE)
+                .build());
+  }
+
+  @Test
+  void generatesUpsertRequestsForUpsertAll() {
+    when(this.mockStub.upsertConfig(any()))
+        .thenAnswer(
+            invocation ->
+                UpsertConfigResponse.newBuilder()
+                    .setConfig(((UpsertConfigRequest) invocation.getArguments()[0]).getConfig())
+                    .build());
+    assertEquals(
+        List.of(OBJECT_1, OBJECT_2),
+        this.store.upsertObjects(this.mockRequestContext, List.of(OBJECT_1, OBJECT_2)));
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("first-id")
+                .setConfig(OBJECT_1_AS_VALUE)
+                .build());
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("second-id")
+                .setConfig(OBJECT_2_AS_VALUE)
+                .build());
+  }
+
+  @lombok.Value
+  @Builder
+  private static class TestObject {
+    String id;
+    int rank;
+  }
+
+  private static class TestObjectStore extends IdentifiedObjectStore<TestObject> {
+    private TestObjectStore(ConfigServiceBlockingStub stub) {
+      super(stub, TEST_RESOURCE_NAMESPACE, TEST_RESOURCE_NAME);
+    }
+
+    @Override
+    protected Optional<TestObject> buildObjectFromValue(Value value) {
+      return Optional.of(
+          TestObject.builder()
+              .rank((int) value.getStructValue().getFieldsOrThrow("rank").getNumberValue())
+              .id(value.getStructValue().getFieldsOrThrow("id").getStringValue())
+              .build());
+    }
+
+    @Override
+    protected Value buildValueFromObject(TestObject object) {
+      return Value.newBuilder()
+          .setStructValue(
+              Struct.newBuilder()
+                  .putFields("id", Values.of(object.getId()))
+                  .putFields("rank", Values.of(object.getRank())))
+          .build();
+    }
+
+    @Override
+    protected String getContextFromObject(TestObject object) {
+      return object.getId();
+    }
+
+    @Override
+    protected List<TestObject> orderFetchedObjects(List<TestObject> objects) {
+      return objects.stream()
+          .sorted(Comparator.comparing(TestObject::getRank))
+          .collect(Collectors.toUnmodifiableList());
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(":config-service-impl")
 include(":config-service")
 
 include(":config-proto-converter")
+include(":object-store")
 
 include(":spaces-config-service-api")
 include(":spaces-config-service-impl")


### PR DESCRIPTION
## Description
Config services generally add an abstraction layer over the generic config rpc service, which take a very repetitive form - either for identified many-object config, or a single tenant-scoped config. Reusable abstractions for both are added here.

### Testing
Added UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

