### PR TITLE
feat: return deleted value from object store's delete

### DIFF
--- a/alerting-config-service-impl/src/main/java/org/hypertrace/alerting/config/service/EventConditionConfigServiceImpl.java
+++ b/alerting-config-service-impl/src/main/java/org/hypertrace/alerting/config/service/EventConditionConfigServiceImpl.java
@@ -1,6 +1,7 @@
 package org.hypertrace.alerting.config.service;
 
 import io.grpc.Channel;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -100,7 +101,9 @@ public class EventConditionConfigServiceImpl
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       requestValidator.validateDeleteEventConditionRequest(requestContext, request);
-      eventConditionStore.deleteObject(requestContext, request.getEventConditionId());
+      eventConditionStore
+          .deleteObject(requestContext, request.getEventConditionId())
+          .orElseThrow(Status.NOT_FOUND::asRuntimeException);
       responseObserver.onNext(DeleteEventConditionResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/label-application-rule-config-service-impl/src/main/java/org/hypertrace/label/application/rule/config/service/LabelApplicationRuleConfigServiceImpl.java
+++ b/label-application-rule-config-service-impl/src/main/java/org/hypertrace/label/application/rule/config/service/LabelApplicationRuleConfigServiceImpl.java
@@ -108,7 +108,9 @@ public class LabelApplicationRuleConfigServiceImpl
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       this.requestValidator.validateOrThrow(requestContext, request);
-      this.labelApplicationRuleStore.deleteObject(requestContext, request.getId());
+      this.labelApplicationRuleStore
+          .deleteObject(requestContext, request.getId())
+          .orElseThrow(Status.NOT_FOUND::asRuntimeException);
       responseObserver.onNext(DeleteLabelApplicationRuleResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/notification-channel-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceImpl.java
+++ b/notification-channel-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceImpl.java
@@ -108,7 +108,9 @@ public class NotificationChannelConfigServiceImpl
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       validator.validateDeleteNotificationChannelRequest(requestContext, request);
-      notificationChannelStore.deleteObject(requestContext, request.getNotificationChannelId());
+      notificationChannelStore
+          .deleteObject(requestContext, request.getNotificationChannelId())
+          .orElseThrow(Status.NOT_FOUND::asRuntimeException);
       responseObserver.onNext(DeleteNotificationChannelResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImpl.java
+++ b/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImpl.java
@@ -104,7 +104,9 @@ public class NotificationRuleConfigServiceImpl
     try {
       RequestContext requestContext = RequestContext.CURRENT.get();
       validator.validateDeleteNotificationRuleRequest(requestContext, request);
-      notificationRuleStore.deleteObject(requestContext, request.getNotificationRuleId());
+      notificationRuleStore
+          .deleteObject(requestContext, request.getNotificationRuleId())
+          .orElseThrow(Status.NOT_FOUND::asRuntimeException);
       responseObserver.onNext(DeleteNotificationRuleResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/object-store/src/main/java/org/hypertrace/config/objectstore/DefaultObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/DefaultObjectStore.java
@@ -72,19 +72,27 @@ public abstract class DefaultObjectStore<T> {
         .orElseThrow(Status.INTERNAL::asRuntimeException);
   }
 
-  public T deleteObject(RequestContext context) {
-    Value deletedValue =
-        context
-            .call(
-                () ->
-                    this.configServiceBlockingStub.deleteConfig(
-                        DeleteConfigRequest.newBuilder()
-                            .setResourceName(this.resourceName)
-                            .setResourceNamespace(this.resourceNamespace)
-                            .build()))
-            .getDeletedConfig()
-            .getConfig();
-
-    return this.buildObjectFromValue(deletedValue).orElseThrow(Status.INTERNAL::asRuntimeException);
+  public Optional<T> deleteObject(RequestContext context) {
+    try {
+      Value deletedValue =
+          context
+              .call(
+                  () ->
+                      this.configServiceBlockingStub.deleteConfig(
+                          DeleteConfigRequest.newBuilder()
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .build()))
+              .getDeletedConfig()
+              .getConfig();
+      T object =
+          this.buildObjectFromValue(deletedValue).orElseThrow(Status.INTERNAL::asRuntimeException);
+      return Optional.of(object);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
   }
 }

--- a/object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
@@ -103,21 +103,29 @@ public abstract class IdentifiedObjectStore<T> {
         .orElseThrow(Status.INTERNAL::asRuntimeException);
   }
 
-  public T deleteObject(RequestContext context, String id) {
-    Value deletedValue =
-        context
-            .call(
-                () ->
-                    this.configServiceBlockingStub.deleteConfig(
-                        DeleteConfigRequest.newBuilder()
-                            .setResourceName(this.resourceName)
-                            .setResourceNamespace(this.resourceNamespace)
-                            .setContext(id)
-                            .build()))
-            .getDeletedConfig()
-            .getConfig();
-
-    return this.buildObjectFromValue(deletedValue).orElseThrow(Status.INTERNAL::asRuntimeException);
+  public Optional<T> deleteObject(RequestContext context, String id) {
+    try {
+      Value deletedValue =
+          context
+              .call(
+                  () ->
+                      this.configServiceBlockingStub.deleteConfig(
+                          DeleteConfigRequest.newBuilder()
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .setContext(id)
+                              .build()))
+              .getDeletedConfig()
+              .getConfig();
+      T object =
+          this.buildObjectFromValue(deletedValue).orElseThrow(Status.INTERNAL::asRuntimeException);
+      return Optional.of(object);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
   }
 
   public List<T> upsertObjects(RequestContext context, List<T> objects) {

--- a/object-store/src/test/java/DefaultObjectStoreTest.java
+++ b/object-store/src/test/java/DefaultObjectStoreTest.java
@@ -79,7 +79,7 @@ class DefaultObjectStoreTest {
             DeleteConfigResponse.newBuilder()
                 .setDeletedConfig(ContextSpecificConfig.newBuilder().setConfig(Values.of("test")))
                 .build());
-    assertEquals(new TestObject("test"), this.store.deleteObject(mockRequestContext));
+    assertEquals(Optional.of(new TestObject("test")), this.store.deleteObject(mockRequestContext));
 
     verify(this.mockStub)
         .deleteConfig(
@@ -87,6 +87,10 @@ class DefaultObjectStoreTest {
                 .setResourceName(TEST_RESOURCE_NAME)
                 .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
                 .build());
+
+    when(this.mockStub.deleteConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.deleteObject(mockRequestContext));
   }
 
   @Test

--- a/object-store/src/test/java/IdentifiedObjectStoreTest.java
+++ b/object-store/src/test/java/IdentifiedObjectStoreTest.java
@@ -127,7 +127,7 @@ class IdentifiedObjectStoreTest {
             DeleteConfigResponse.newBuilder()
                 .setDeletedConfig(ContextSpecificConfig.newBuilder().setConfig(OBJECT_1_AS_VALUE))
                 .build());
-    assertEquals(OBJECT_1, this.store.deleteObject(mockRequestContext, "some-id"));
+    assertEquals(Optional.of(OBJECT_1), this.store.deleteObject(mockRequestContext, "some-id"));
 
     verify(this.mockStub)
         .deleteConfig(
@@ -136,6 +136,10 @@ class IdentifiedObjectStoreTest {
                 .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
                 .setContext("some-id")
                 .build());
+
+    when(this.mockStub.deleteConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.deleteObject(mockRequestContext, "some-id"));
   }
 
   @Test


### PR DESCRIPTION
## Description
Make ObjectStore's delete return the deleted value, matching the grpc's API.

### Testing
Updated existing unit tests, verified integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
