### PR TITLE
feat: add contextually identified object store

### DIFF
--- a/object-store/src/main/java/org/hypertrace/config/objectstore/ContextuallyIdentifiedObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/ContextuallyIdentifiedObjectStore.java
@@ -1,0 +1,93 @@
+package org.hypertrace.config.objectstore;
+
+import com.google.protobuf.Value;
+import java.util.Optional;
+import org.hypertrace.config.service.change.event.api.ConfigChangeEventGenerator;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+
+public abstract class ContextuallyIdentifiedObjectStore<T> {
+  private final ConfigServiceBlockingStub configServiceBlockingStub;
+  private final String resourceNamespace;
+  private final String resourceName;
+  private final Optional<ConfigChangeEventGenerator> configChangeEventGenerator;
+
+  protected ContextuallyIdentifiedObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName,
+      ConfigChangeEventGenerator configChangeEventGenerator) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+    this.configChangeEventGenerator = Optional.of(configChangeEventGenerator);
+  }
+
+  protected ContextuallyIdentifiedObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+    this.configChangeEventGenerator = Optional.empty();
+  }
+
+  protected abstract Optional<T> buildObjectFromValue(Value value);
+
+  protected abstract Value buildValueFromObject(T object);
+
+  protected abstract String getConfigContextFromRequestContext(RequestContext requestContext);
+
+  private IdentifiedObjectStore<T> buildObjectStoreForContext(RequestContext context) {
+    return this.configChangeEventGenerator
+        .map(generator -> new ContextAwareIdentifiedObjectStoreDelegate(context, generator))
+        .orElseGet(() -> new ContextAwareIdentifiedObjectStoreDelegate(context));
+  }
+
+  public Optional<T> getObject(RequestContext context) {
+    return this.buildObjectStoreForContext(context)
+        .getObject(context, this.getConfigContextFromRequestContext(context));
+  }
+
+  public T upsertObject(RequestContext context, T object) {
+    return this.buildObjectStoreForContext(context).upsertObject(context, object);
+  }
+
+  public Optional<T> deleteObject(RequestContext context) {
+    return this.buildObjectStoreForContext(context)
+        .deleteObject(context, this.getConfigContextFromRequestContext(context));
+  }
+
+  private class ContextAwareIdentifiedObjectStoreDelegate extends IdentifiedObjectStore<T> {
+
+    private final RequestContext requestContext;
+
+    ContextAwareIdentifiedObjectStoreDelegate(RequestContext requestContext) {
+      super(configServiceBlockingStub, resourceNamespace, resourceName);
+      this.requestContext = requestContext;
+    }
+
+    ContextAwareIdentifiedObjectStoreDelegate(
+        RequestContext requestContext, ConfigChangeEventGenerator configChangeEventGenerator) {
+      super(configServiceBlockingStub, resourceNamespace, resourceName, configChangeEventGenerator);
+      this.requestContext = requestContext;
+    }
+
+    @Override
+    protected Optional<T> buildObjectFromValue(Value value) {
+      return ContextuallyIdentifiedObjectStore.this.buildObjectFromValue(value);
+    }
+
+    @Override
+    protected Value buildValueFromObject(T object) {
+      return ContextuallyIdentifiedObjectStore.this.buildValueFromObject(object);
+    }
+
+    @Override
+    protected String getContextFromObject(T object) {
+      return ContextuallyIdentifiedObjectStore.this.getConfigContextFromRequestContext(
+          requestContext);
+    }
+  }
+}

--- a/object-store/src/test/java/ContextuallyIdentifiedObjectStoreTest.java
+++ b/object-store/src/test/java/ContextuallyIdentifiedObjectStoreTest.java
@@ -1,0 +1,141 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Value;
+import com.google.protobuf.util.Values;
+import io.grpc.Status;
+import java.util.Optional;
+import org.hypertrace.config.objectstore.ContextuallyIdentifiedObjectStore;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContextuallyIdentifiedObjectStoreTest {
+  private static final String TEST_RESOURCE_NAMESPACE = "test-namespace";
+  private static final String TEST_RESOURCE_NAME = "test-resource";
+
+  @Mock ConfigServiceBlockingStub mockStub;
+
+  ContextuallyIdentifiedObjectStore<TestObject> store;
+
+  @BeforeEach
+  void beforeEach() {
+    this.mockStub = mock(ConfigServiceBlockingStub.class);
+    this.store = new TestObjectStore(this.mockStub);
+  }
+
+  @Test
+  void generatesConfigReadRequestForGet() {
+    when(this.mockStub.getConfig(any()))
+        .thenReturn(GetConfigResponse.newBuilder().setConfig(Values.of("test")).build());
+    assertEquals(
+        Optional.of(new TestObject("test")),
+        this.store.getObject(RequestContext.forTenantId("my-tenant")));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .addContexts("my-tenant")
+                .build());
+
+    when(this.mockStub.getConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(
+        Optional.empty(), this.store.getObject(RequestContext.forTenantId("my-other-tenant")));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .addContexts("my-other-tenant")
+                .build());
+  }
+
+  @Test
+  void generatesConfigDeleteRequest() {
+    when(this.mockStub.deleteConfig(any()))
+        .thenReturn(
+            DeleteConfigResponse.newBuilder()
+                .setDeletedConfig(ContextSpecificConfig.newBuilder().setConfig(Values.of("test")))
+                .build());
+    assertEquals(
+        Optional.of(new TestObject("test")),
+        this.store.deleteObject(RequestContext.forTenantId("delete-tenant")));
+
+    verify(this.mockStub)
+        .deleteConfig(
+            DeleteConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("delete-tenant")
+                .build());
+
+    when(this.mockStub.deleteConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(
+        Optional.empty(), this.store.deleteObject(RequestContext.forTenantId("delete-tenant")));
+  }
+
+  @Test
+  void generatesConfigUpsertRequest() {
+    when(this.mockStub.upsertConfig(any()))
+        .thenReturn(UpsertConfigResponse.newBuilder().setConfig(Values.of("updated")).build());
+    assertEquals(
+        new TestObject("updated"),
+        this.store.upsertObject(
+            RequestContext.forTenantId("upsert-tenant"), new TestObject("updated")));
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setContext("upsert-tenant")
+                .setConfig(Values.of("updated"))
+                .build());
+  }
+
+  @lombok.Value
+  private static class TestObject {
+    String name;
+  }
+
+  private static class TestObjectStore extends ContextuallyIdentifiedObjectStore<TestObject> {
+    private TestObjectStore(ConfigServiceBlockingStub stub) {
+      super(stub, TEST_RESOURCE_NAMESPACE, TEST_RESOURCE_NAME);
+    }
+
+    @Override
+    protected Optional<TestObject> buildObjectFromValue(Value value) {
+      return Optional.of(new TestObject(value.getStringValue()));
+    }
+
+    @Override
+    protected Value buildValueFromObject(TestObject object) {
+      return Values.of(object.getName());
+    }
+
+    @Override
+    protected String getConfigContextFromRequestContext(RequestContext requestContext) {
+      return requestContext.getTenantId().orElseThrow();
+    }
+  }
+}


### PR DESCRIPTION
## Description
In some scenarios, we generate the ID for a config object from the request context (for example, identified by tenant). With this new variant of object store, callers can use the request context without either breaking the existing contract for DefaultObject Store or hacking around by passing an "extra argument" through a thread local. All logic is still delegated and shared with existing implementations.

### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
