### PR TITLE
fix: update snyk

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -76,6 +76,6 @@ jobs:
       - name: Setup snyk
         uses: snyk/actions/setup@0.3.0
       - name: Snyk test
-        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$'
+        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$' --remote-repo-url='${{ github.server_url }}/${{ github.repository }}.git'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/config-service-change-event-generator/build.gradle.kts
+++ b/config-service-change-event-generator/build.gradle.kts
@@ -18,6 +18,14 @@ dependencies {
   compileOnly(libs.lombok)
 
   runtimeOnly(libs.kafka.protobuf.serializer)
+  constraints {
+    runtimeOnly("org.glassfish.jersey.core:jersey-common:2.34") {
+      because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
+    }
+    runtimeOnly("org.apache.commons:commons-compress:1.21") {
+      because("Multiple vulnerabilities")
+    }
+  }
 
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.mockito.core)


### PR DESCRIPTION
## Description
Snyk changed their server implementation, and the default remote uri detection no longer works. After weeks with snyk support, they made some changes and now this works, we need to add this param for all invocations