### PR TITLE
fix: upsert all config mock

### DIFF
--- a/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
+++ b/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
@@ -271,7 +271,7 @@ public class MockGenericConfigService {
               return null;
             })
         .when(this.mockConfigService)
-        .upsertConfig(ArgumentMatchers.any(), ArgumentMatchers.any());
+        .upsertAllConfigs(ArgumentMatchers.any(), ArgumentMatchers.any());
 
     return this;
   }


### PR DESCRIPTION
## Description
Newly added upsertAll mock was matching the wrong method. Fixed.

### Testing
Verified when writing a test against upsertAll mock
