### PR TITLE
added new object store to use external context

### DIFF
--- a/object-store/src/main/java/org/hypertrace/config/objectstore/ExternalContextIdentifiedObjectStore.java
+++ b/object-store/src/main/java/org/hypertrace/config/objectstore/ExternalContextIdentifiedObjectStore.java
@@ -1,0 +1,157 @@
+package org.hypertrace.config.objectstore;
+
+import com.google.protobuf.Value;
+import io.grpc.Status;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.config.service.change.event.api.ConfigChangeEventGenerator;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+
+/**
+ * ExternalContextIdentifiedObjectStore is an abstraction over the grpc api for config
+ * implementations working with single object with identifier obtained from outside the data object
+ * - a pattern often used for a tenant-wide config.
+ *
+ * @param <T>
+ */
+@Slf4j
+public abstract class ExternalContextIdentifiedObjectStore<T> {
+  private final ConfigServiceBlockingStub configServiceBlockingStub;
+  private final String resourceNamespace;
+  private final String resourceName;
+  private final Optional<ConfigChangeEventGenerator> configChangeEventGeneratorOptional;
+
+  protected ExternalContextIdentifiedObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName,
+      ConfigChangeEventGenerator configChangeEventGenerator) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+    this.configChangeEventGeneratorOptional = Optional.of(configChangeEventGenerator);
+  }
+
+  protected ExternalContextIdentifiedObjectStore(
+      ConfigServiceBlockingStub configServiceBlockingStub,
+      String resourceNamespace,
+      String resourceName) {
+    this.configServiceBlockingStub = configServiceBlockingStub;
+    this.resourceNamespace = resourceNamespace;
+    this.resourceName = resourceName;
+    this.configChangeEventGeneratorOptional = Optional.empty();
+  }
+
+  protected abstract Optional<T> buildDataFromValue(Value value);
+
+  protected abstract Value buildValueFromData(T data);
+
+  protected Value buildValueForChangeEvent(T data) {
+    return this.buildValueFromData(data);
+  }
+
+  protected String buildClassNameForChangeEvent(T data) {
+    return data.getClass().getName();
+  }
+
+  public Optional<T> getData(RequestContext context) {
+    try {
+      Value value =
+          context.call(
+              () ->
+                  this.configServiceBlockingStub
+                      .getConfig(
+                          GetConfigRequest.newBuilder()
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .build())
+                      .getConfig());
+      T data = this.buildDataFromValue(value).orElseThrow(Status.INTERNAL::asRuntimeException);
+      return Optional.of(data);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
+  }
+
+  public ConfigObject<T> upsertObject(RequestContext context, String dataContext, T data) {
+    UpsertConfigResponse response =
+        context.call(
+            () ->
+                this.configServiceBlockingStub.upsertConfig(
+                    UpsertConfigRequest.newBuilder()
+                        .setContext(dataContext)
+                        .setResourceName(this.resourceName)
+                        .setResourceNamespace(this.resourceNamespace)
+                        .setConfig(this.buildValueFromData(data))
+                        .build()));
+
+    ConfigObject<T> upsertedObject =
+        ConfigObjectImpl.tryBuild(response, this::buildDataFromValue)
+            .orElseThrow(Status.INTERNAL::asRuntimeException);
+
+    configChangeEventGeneratorOptional.ifPresent(
+        configChangeEventGenerator -> {
+          if (response.hasPrevConfig()) {
+            configChangeEventGenerator.sendUpdateNotification(
+                context,
+                this.buildClassNameForChangeEvent(upsertedObject.getData()),
+                this.buildDataFromValue(response.getPrevConfig())
+                    .map(this::buildValueForChangeEvent)
+                    .orElseGet(
+                        () -> {
+                          log.error(
+                              "Unable to convert previousValue back to data for change event. Falling back to raw value {}",
+                              response.getPrevConfig());
+                          return response.getPrevConfig();
+                        }),
+                this.buildValueForChangeEvent(upsertedObject.getData()));
+          } else {
+            configChangeEventGenerator.sendCreateNotification(
+                context,
+                this.buildClassNameForChangeEvent(upsertedObject.getData()),
+                this.buildValueForChangeEvent(upsertedObject.getData()));
+          }
+        });
+    return upsertedObject;
+  }
+
+  public Optional<ConfigObject<T>> deleteObject(RequestContext context, String id) {
+    try {
+      ContextSpecificConfig deletedConfig =
+          context
+              .call(
+                  () ->
+                      this.configServiceBlockingStub.deleteConfig(
+                          DeleteConfigRequest.newBuilder()
+                              .setContext(id)
+                              .setResourceName(this.resourceName)
+                              .setResourceNamespace(this.resourceNamespace)
+                              .build()))
+              .getDeletedConfig();
+      ConfigObject<T> object =
+          ConfigObjectImpl.tryBuild(deletedConfig, this::buildDataFromValue)
+              .orElseThrow(Status.INTERNAL::asRuntimeException);
+      configChangeEventGeneratorOptional.ifPresent(
+          configChangeEventGenerator ->
+              configChangeEventGenerator.sendDeleteNotification(
+                  context,
+                  this.buildClassNameForChangeEvent(object.getData()),
+                  this.buildValueForChangeEvent(object.getData())));
+      return Optional.of(object);
+    } catch (Exception exception) {
+      if (Status.fromThrowable(exception).equals(Status.NOT_FOUND)) {
+        return Optional.empty();
+      }
+      throw exception;
+    }
+  }
+}

--- a/object-store/src/test/java/org/hypertrace/config/objectstore/ExternalContextIdentifiedObjectStoreTest.java
+++ b/object-store/src/test/java/org/hypertrace/config/objectstore/ExternalContextIdentifiedObjectStoreTest.java
@@ -1,0 +1,196 @@
+package org.hypertrace.config.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.Values;
+import io.grpc.Status;
+import java.time.Instant;
+import java.util.Optional;
+import org.hypertrace.config.service.change.event.api.ConfigChangeEventGenerator;
+import org.hypertrace.config.service.v1.ConfigServiceGrpc.ConfigServiceBlockingStub;
+import org.hypertrace.config.service.v1.ContextSpecificConfig;
+import org.hypertrace.config.service.v1.DeleteConfigRequest;
+import org.hypertrace.config.service.v1.DeleteConfigResponse;
+import org.hypertrace.config.service.v1.GetConfigRequest;
+import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertConfigRequest;
+import org.hypertrace.config.service.v1.UpsertConfigResponse;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalContextIdentifiedObjectStoreTest {
+  private static final String TEST_RESOURCE_NAMESPACE = "test-namespace";
+  private static final String TEST_RESOURCE_NAME = "test-resource";
+  private static final String DATA_CONTEXT = "context";
+  private static final Instant TEST_CREATE_TIMESTAMP = Instant.ofEpochMilli(20);
+  private static final Instant TEST_UPDATE_TIMESTAMP = Instant.ofEpochMilli(40);
+
+  @Mock ConfigServiceBlockingStub mockStub;
+
+  @Mock ConfigChangeEventGenerator configChangeEventGenerator;
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  RequestContext mockRequestContext;
+
+  ExternalContextIdentifiedObjectStore<TestInternalObject> store;
+
+  @BeforeEach
+  void beforeEach() {
+    this.mockStub = mock(ConfigServiceBlockingStub.class);
+    this.store = new TestObjectStore(this.mockStub, configChangeEventGenerator);
+  }
+
+  @Test
+  void generatesConfigReadRequestForGet() {
+    when(this.mockStub.getConfig(any()))
+        .thenReturn(GetConfigResponse.newBuilder().setConfig(Values.of("test")).build());
+
+    assertEquals(
+        Optional.of(new TestInternalObject("test")), this.store.getData(this.mockRequestContext));
+
+    verify(this.mockStub, times(1))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+
+    when(this.mockStub.getConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.getData(this.mockRequestContext));
+
+    verify(this.mockStub, times(2))
+        .getConfig(
+            GetConfigRequest.newBuilder()
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+  }
+
+  @Test
+  void generatesConfigDeleteRequest() {
+    when(this.mockStub.deleteConfig(any()))
+        .thenReturn(
+            DeleteConfigResponse.newBuilder()
+                .setDeletedConfig(
+                    ContextSpecificConfig.newBuilder()
+                        .setConfig(Values.of("test"))
+                        .setCreationTimestamp(TEST_CREATE_TIMESTAMP.toEpochMilli())
+                        .setUpdateTimestamp(TEST_UPDATE_TIMESTAMP.toEpochMilli()))
+                .build());
+    assertEquals(
+        Optional.of(
+            new ConfigObjectImpl<>(
+                new TestInternalObject("test"), TEST_CREATE_TIMESTAMP, TEST_UPDATE_TIMESTAMP)),
+        this.store.deleteObject(mockRequestContext, DATA_CONTEXT));
+
+    verify(this.mockStub)
+        .deleteConfig(
+            DeleteConfigRequest.newBuilder()
+                .setContext(DATA_CONTEXT)
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .build());
+
+    when(this.mockStub.deleteConfig(any())).thenThrow(Status.NOT_FOUND.asRuntimeException());
+
+    assertEquals(Optional.empty(), this.store.deleteObject(mockRequestContext, DATA_CONTEXT));
+
+    verify(this.configChangeEventGenerator, times(1))
+        .sendDeleteNotification(
+            eq(this.mockRequestContext),
+            eq(TestApiObject.class.getName()),
+            eq(
+                Value.newBuilder()
+                    .setStructValue(Struct.newBuilder().putFields("api_name", Values.of("test")))
+                    .build()));
+  }
+
+  @Test
+  void generatesConfigUpsertRequest() {
+    when(this.mockStub.upsertConfig(any()))
+        .thenReturn(
+            UpsertConfigResponse.newBuilder()
+                .setCreationTimestamp(TEST_CREATE_TIMESTAMP.toEpochMilli())
+                .setUpdateTimestamp(TEST_UPDATE_TIMESTAMP.toEpochMilli())
+                .setConfig(Values.of("updated"))
+                .build());
+    ConfigObject configObject =
+        new ConfigObjectImpl<>(
+            new TestInternalObject("updated"), TEST_CREATE_TIMESTAMP, TEST_UPDATE_TIMESTAMP);
+    assertEquals(
+        configObject,
+        this.store.upsertObject(
+            this.mockRequestContext, DATA_CONTEXT, new TestInternalObject("updated")));
+    verify(this.mockStub, times(1))
+        .upsertConfig(
+            UpsertConfigRequest.newBuilder()
+                .setContext(DATA_CONTEXT)
+                .setResourceName(TEST_RESOURCE_NAME)
+                .setResourceNamespace(TEST_RESOURCE_NAMESPACE)
+                .setConfig(Values.of("updated"))
+                .build());
+    verify(this.configChangeEventGenerator, times(1))
+        .sendCreateNotification(
+            eq(this.mockRequestContext),
+            eq(TestApiObject.class.getName()),
+            eq(
+                Value.newBuilder()
+                    .setStructValue(Struct.newBuilder().putFields("api_name", Values.of("updated")))
+                    .build()));
+  }
+
+  @lombok.Value
+  private static class TestInternalObject {
+    String name;
+  }
+
+  @lombok.Value
+  private static class TestApiObject {
+    String api_name;
+  }
+
+  private static class TestObjectStore
+      extends ExternalContextIdentifiedObjectStore<TestInternalObject> {
+    private TestObjectStore(
+        ConfigServiceBlockingStub stub, ConfigChangeEventGenerator configChangeEventGenerator) {
+      super(stub, TEST_RESOURCE_NAMESPACE, TEST_RESOURCE_NAME, configChangeEventGenerator);
+    }
+
+    @Override
+    protected Optional<TestInternalObject> buildDataFromValue(Value value) {
+      return Optional.of(new TestInternalObject(value.getStringValue()));
+    }
+
+    @Override
+    protected Value buildValueFromData(TestInternalObject object) {
+      return Values.of(object.getName());
+    }
+
+    @Override
+    protected Value buildValueForChangeEvent(TestInternalObject object) {
+      return Value.newBuilder()
+          .setStructValue(Struct.newBuilder().putFields("api_name", Values.of(object.getName())))
+          .build();
+    }
+
+    @Override
+    protected String buildClassNameForChangeEvent(TestInternalObject object) {
+      return TestApiObject.class.getName();
+    }
+  }
+}


### PR DESCRIPTION
## Description
Added a new object store abstraction to use context that has been provided separately. (Needed in cases where the identifying context cannot be extracted either from the data object or request context)
