### PR TITLE
Removing version from document store key

### DIFF
--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocumentKey.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/ConfigDocumentKey.java
@@ -9,9 +9,9 @@ import org.hypertrace.core.documentstore.Key;
 public class ConfigDocumentKey implements Key {
 
   private static final String SEPARATOR = ":";
+  private static final String LATEST_VERSION = "latest";
 
   ConfigResourceContext configResourceContext;
-  long configVersion;
 
   @Override
   public String toString() {
@@ -21,6 +21,6 @@ public class ConfigDocumentKey implements Key {
         configResourceContext.getConfigResource().getResourceNamespace(),
         configResourceContext.getConfigResource().getTenantId(),
         configResourceContext.getContext(),
-        String.valueOf(configVersion));
+        LATEST_VERSION);
   }
 }

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -100,7 +100,7 @@ public class DocumentConfigStore implements ConfigStore {
               .map(ConfigDocument::getConfigVersion)
               .map(previousVersion -> previousVersion + 1)
               .orElse(1L);
-      Key latestDocKey = new ConfigDocumentKey(configResourceContext, newVersion);
+      Key latestDocKey = new ConfigDocumentKey(configResourceContext);
       ConfigDocument latestConfigDocument =
           new ConfigDocument(
               configResourceContext.getConfigResource().getResourceName(),

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
@@ -96,7 +96,7 @@ class DocumentConfigStoreTest {
     Key key = keyCaptor.getValue();
     Document document = documentCaptor.getValue();
     long newVersion = CONFIG_VERSION + 1;
-    assertEquals(new ConfigDocumentKey(configResourceContext, newVersion), key);
+    assertEquals(new ConfigDocumentKey(configResourceContext), key);
     assertEquals(
         getConfigDocument(
             configResourceContext.getContext(),
@@ -208,7 +208,7 @@ class DocumentConfigStoreTest {
 
     verify(collection, times(1))
         .upsert(
-            new ConfigDocumentKey(resourceContext1, CONFIG_VERSION + 1),
+            new ConfigDocumentKey(resourceContext1),
             getConfigDocument(
                 resourceContext1.getContext(),
                 CONFIG_VERSION + 1,
@@ -217,7 +217,7 @@ class DocumentConfigStoreTest {
                 updateTime));
     verify(collection, times(1))
         .upsert(
-            new ConfigDocumentKey(resourceContext2, CONFIG_VERSION + 1),
+            new ConfigDocumentKey(resourceContext2),
             getConfigDocument(
                 resourceContext2.getContext(),
                 CONFIG_VERSION + 1,


### PR DESCRIPTION
Removing version from document store key. Using static "latest" instead. This will ensure only latest version is maintained in the document store. The version history is published by config change events, and can be potentially captured in audit logs.