### PR TITLE
refactor: replace lock with unique constraint

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ hypertrace-documentstore = { module = "org.hypertrace.core.documentstore:documen
 hypertrace-eventstore = { module = "org.hypertrace.core.eventstore:event-store", version = "0.1.2" }
 
 guava = { module = "com.google.guava:guava", version = "31.1-jre" }
+rholder-guava-retrying = { module =  "com.github.rholder:guava-retrying", version = "2.0.0" }
 guice = { module = "com.google.inject:guice", version = "5.0.1" }
 javax-annotation = { module = "javax.annotation:javax.annotation-api", version = "1.3.2" }
 typesafe-config = { module = "com.typesafe:config", version = "1.4.1" }

--- a/labels-config-service-impl/build.gradle.kts
+++ b/labels-config-service-impl/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.protobuf.javautil)
     implementation(libs.slf4j.api)
     implementation(libs.guava)
+    implementation(libs.rholder.guava.retrying)
     implementation(libs.rxjava3)
 
     implementation(libs.hypertrace.grpcutils.context)


### PR DESCRIPTION
## Description
Rather than using an in-memory lock, which prevents horizontal scaling, we're changing the label getOrCreate method here to retry. In conjunction with a separate change to add a unique constraint on the key, this should result in the lock being unnecessary. Concurrent calls may result in an error in the scenario where a label was checked for existence - returned false, then attempted to create and was created in the lag time. In this scenario, we attempt the method again under the assumption the initial read call will work the second time. If we can neither get nor create after two attempts, we give up. In no scenario do we ever end up with duplicates.


### Testing
TODO

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
