### PR TITLE
fix: add request validation for creation of system exclude rule

### DIFF
--- a/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/validation/SpanProcessingConfigRequestValidator.java
+++ b/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/validation/SpanProcessingConfigRequestValidator.java
@@ -3,6 +3,7 @@ package org.hypertrace.span.processing.config.service.validation;
 import static org.hypertrace.config.validation.GrpcValidatorUtils.printMessage;
 import static org.hypertrace.config.validation.GrpcValidatorUtils.validateNonDefaultPresenceOrThrow;
 import static org.hypertrace.config.validation.GrpcValidatorUtils.validateRequestContextOrThrow;
+import static org.hypertrace.span.processing.config.service.v1.RuleType.RULE_TYPE_SYSTEM;
 
 import com.google.common.base.Strings;
 import com.google.re2j.Pattern;
@@ -39,6 +40,13 @@ public class SpanProcessingConfigRequestValidator {
   public void validateOrThrow(RequestContext requestContext, CreateExcludeSpanRuleRequest request) {
     validateRequestContextOrThrow(requestContext);
     this.validateData(request.getRuleInfo());
+    if (RULE_TYPE_SYSTEM.equals(request.getRuleInfo().getType())) {
+      throw Status.INVALID_ARGUMENT
+          .withDescription(
+              String.format(
+                  "Invalid rule type to create system level rule : %s", request.getRuleInfo()))
+          .asRuntimeException();
+    }
   }
 
   public void validateOrThrow(RequestContext requestContext, UpdateExcludeSpanRuleRequest request) {

--- a/span-processing-config-service-impl/src/test/java/org/hypertrace/span/processing/config/service/validation/SpanProcessingRequestValidatorTest.java
+++ b/span-processing-config-service-impl/src/test/java/org/hypertrace/span/processing/config/service/validation/SpanProcessingRequestValidatorTest.java
@@ -1,5 +1,7 @@
 package org.hypertrace.span.processing.config.service.validation;
 
+import static org.hypertrace.span.processing.config.service.v1.RuleType.RULE_TYPE_SYSTEM;
+import static org.hypertrace.span.processing.config.service.v1.RuleType.RULE_TYPE_USER;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,7 +103,21 @@ class SpanProcessingRequestValidatorTest {
             validator.validateOrThrow(
                 mockRequestContext,
                 CreateExcludeSpanRuleRequest.newBuilder()
-                    .setRuleInfo(ExcludeSpanRuleInfo.newBuilder().build())
+                    .setRuleInfo(ExcludeSpanRuleInfo.newBuilder().setType(RULE_TYPE_USER).build())
+                    .build()));
+
+    assertInvalidArgStatusContaining(
+        "Invalid rule type to create system level rule",
+        () ->
+            validator.validateOrThrow(
+                mockRequestContext,
+                CreateExcludeSpanRuleRequest.newBuilder()
+                    .setRuleInfo(
+                        ExcludeSpanRuleInfo.newBuilder()
+                            .setName("name")
+                            .setType(RULE_TYPE_SYSTEM)
+                            .setFilter(buildTestFilter())
+                            .build())
                     .build()));
 
     assertDoesNotThrow(
@@ -114,6 +130,7 @@ class SpanProcessingRequestValidatorTest {
                             .setName("name")
                             .setDisabled(true)
                             .setFilter(buildTestFilter())
+                            .setType(RULE_TYPE_USER)
                             .build())
                     .build()));
   }


### PR DESCRIPTION
## Description
This PR adds validation for creation of system exclude span rule(deny it). 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules