### PR TITLE
fix: Optimise bulk creation of api spec based naming rules

### DIFF
--- a/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
+++ b/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
@@ -64,40 +64,37 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
   public List<ApiNamingRuleDetails> createApiNamingRules(
       RequestContext requestContext, CreateApiNamingRulesRequest request) {
     // TODO: need to handle priorities
-    List<ApiNamingRule> segmentMatchingBasedRules =
+    Stream<ApiNamingRule> segmentMatchingBasedRuleStream =
         request.getRulesInfoList().stream()
             .filter(
                 apiNamingRuleInfo ->
                     apiNamingRuleInfo.getRuleConfig().hasSegmentMatchingBasedConfig())
-            .map(apiNamingRuleInfo -> buildApiNamingRule(requestContext, apiNamingRuleInfo))
-            .collect(Collectors.toUnmodifiableList());
+            .map(apiNamingRuleInfo -> buildApiNamingRule(requestContext, apiNamingRuleInfo));
 
-    List<ApiNamingRuleInfo> apiSpecBasedNamingRulesInfo =
+    Stream<ApiNamingRuleInfo> apiSpecBasedNamingRulesInfo =
         request.getRulesInfoList().stream()
-            .filter(apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig())
-            .collect(Collectors.toUnmodifiableList());
-    List<ApiNamingRule> apiSpecBasedRules =
-        buildApiSpecBasedRules(requestContext, apiSpecBasedNamingRulesInfo);
+            .filter(apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig());
+    Stream<ApiNamingRule> apiSpecBasedRuleStream =
+        buildApiSpecBasedNamingRules(requestContext, apiSpecBasedNamingRulesInfo);
 
     return buildApiNamingRuleDetails(
         this.apiNamingRulesConfigStore.upsertObjects(
             requestContext,
-            Stream.concat(segmentMatchingBasedRules.stream(), apiSpecBasedRules.stream())
+            Stream.concat(segmentMatchingBasedRuleStream, apiSpecBasedRuleStream)
                 .collect(Collectors.toUnmodifiableList())));
   }
 
-  private List<ApiNamingRule> buildApiSpecBasedRules(
-      RequestContext requestContext, List<ApiNamingRuleInfo> apiSpecBasedApiNamingRules) {
+  private Stream<ApiNamingRule> buildApiSpecBasedNamingRules(
+      RequestContext requestContext,
+      Stream<ApiNamingRuleInfo> apiSpecBasedApiNamingRuleInfoStream) {
     List<ApiNamingRule> existingApiNamingRules =
         getAllApiNamingRuleDetails(requestContext).stream()
             .map(ApiNamingRuleDetails::getRule)
             .collect(Collectors.toUnmodifiableList());
 
-    return apiSpecBasedApiNamingRules.stream()
-        .map(
-            apiNamingRuleInfo ->
-                createApiSpecBasedNamingRule(existingApiNamingRules, apiNamingRuleInfo))
-        .collect(Collectors.toUnmodifiableList());
+    return apiSpecBasedApiNamingRuleInfoStream.map(
+        apiNamingRuleInfo ->
+            createApiSpecBasedNamingRule(existingApiNamingRules.stream(), apiNamingRuleInfo));
   }
 
   @Override
@@ -200,11 +197,9 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
             .setRuleInfo(apiNamingRuleInfo)
             .build();
       case API_SPEC_BASED_CONFIG:
-        List<ApiNamingRule> existingApiNamingRules =
-            getAllApiNamingRuleDetails(requestContext).stream()
-                .map(ApiNamingRuleDetails::getRule)
-                .collect(Collectors.toUnmodifiableList());
-        return createApiSpecBasedNamingRule(existingApiNamingRules, apiNamingRuleInfo);
+        Stream<ApiNamingRule> existingApiNamingRuleStream =
+            getAllApiNamingRuleDetails(requestContext).stream().map(ApiNamingRuleDetails::getRule);
+        return createApiSpecBasedNamingRule(existingApiNamingRuleStream, apiNamingRuleInfo);
       default:
         log.error("Unrecognized api naming rule config type:{}", apiNamingRuleInfo);
         throw new RuntimeException();
@@ -212,11 +207,11 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
   }
 
   private ApiNamingRule createApiSpecBasedNamingRule(
-      List<ApiNamingRule> existingApiNamingRules, ApiNamingRuleInfo apiNamingRuleInfo) {
+      Stream<ApiNamingRule> existingApiNamingRuleStream, ApiNamingRuleInfo apiNamingRuleInfo) {
     ApiSpecBasedConfig apiSpecBasedConfig =
         apiNamingRuleInfo.getRuleConfig().getApiSpecBasedConfig();
     Optional<ApiNamingRule> apiNamingRuleMaybe =
-        checkIfApiNamingRuleAlreadyExists(existingApiNamingRules, apiNamingRuleInfo);
+        checkIfApiNamingRuleAlreadyExists(existingApiNamingRuleStream, apiNamingRuleInfo);
     if (apiNamingRuleMaybe.isEmpty()) {
       return ApiNamingRule.newBuilder()
           .setId(UUID.randomUUID().toString())
@@ -256,8 +251,8 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
   }
 
   private Optional<ApiNamingRule> checkIfApiNamingRuleAlreadyExists(
-      List<ApiNamingRule> existingApiNamingRules, ApiNamingRuleInfo apiNamingRuleInfo) {
-    return existingApiNamingRules.stream()
+      Stream<ApiNamingRule> existingApiNamingRuleStream, ApiNamingRuleInfo apiNamingRuleInfo) {
+    return existingApiNamingRuleStream
         .filter(
             rule ->
                 rule.getRuleInfo().getRuleConfig().hasApiSpecBasedConfig()

--- a/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
+++ b/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
@@ -72,13 +72,12 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
             .map(apiNamingRuleInfo -> buildApiNamingRule(requestContext, apiNamingRuleInfo))
             .collect(Collectors.toUnmodifiableList());
 
+    List<ApiNamingRuleInfo> apiSpecBasedNamingRulesInfo =
+        request.getRulesInfoList().stream()
+            .filter(apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig())
+            .collect(Collectors.toUnmodifiableList());
     List<ApiNamingRule> apiSpecBasedRules =
-        buildApiSpecBasedRules(
-            requestContext,
-            request.getRulesInfoList().stream()
-                .filter(
-                    apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig())
-                .collect(Collectors.toUnmodifiableList()));
+        buildApiSpecBasedRules(requestContext, apiSpecBasedNamingRulesInfo);
 
     return buildApiNamingRuleDetails(
         this.apiNamingRulesConfigStore.upsertObjects(

--- a/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
+++ b/span-processing-config-service-impl/src/main/java/org/hypertrace/span/processing/config/service/apinamingrules/DefaultApiNamingRulesManager.java
@@ -73,16 +73,32 @@ public class DefaultApiNamingRulesManager implements ApiNamingRulesManager {
             .collect(Collectors.toUnmodifiableList());
 
     List<ApiNamingRule> apiSpecBasedRules =
-        request.getRulesInfoList().stream()
-            .filter(apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig())
-            .map(apiNamingRuleInfo -> buildApiNamingRule(requestContext, apiNamingRuleInfo))
-            .collect(Collectors.toUnmodifiableList());
+        buildApiSpecBasedRules(
+            requestContext,
+            request.getRulesInfoList().stream()
+                .filter(
+                    apiNamingRuleInfo -> apiNamingRuleInfo.getRuleConfig().hasApiSpecBasedConfig())
+                .collect(Collectors.toUnmodifiableList()));
 
     return buildApiNamingRuleDetails(
         this.apiNamingRulesConfigStore.upsertObjects(
             requestContext,
             Stream.concat(segmentMatchingBasedRules.stream(), apiSpecBasedRules.stream())
                 .collect(Collectors.toUnmodifiableList())));
+  }
+
+  private List<ApiNamingRule> buildApiSpecBasedRules(
+      RequestContext requestContext, List<ApiNamingRuleInfo> apiSpecBasedApiNamingRules) {
+    List<ApiNamingRule> existingApiNamingRules =
+        getAllApiNamingRuleDetails(requestContext).stream()
+            .map(ApiNamingRuleDetails::getRule)
+            .collect(Collectors.toUnmodifiableList());
+
+    return apiSpecBasedApiNamingRules.stream()
+        .map(
+            apiNamingRuleInfo ->
+                createApiSpecBasedNamingRule(existingApiNamingRules, apiNamingRuleInfo))
+        .collect(Collectors.toUnmodifiableList());
   }
 
   @Override


### PR DESCRIPTION
## Description
This PR contains a fix to optimise bulk creation of api spec based naming rules.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Verified the success of unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
