### PR TITLE
fix: default config context in mockDelete

### DIFF
--- a/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
+++ b/config-service-api/src/testFixtures/java/org/hypertrace/config/service/test/MockGenericConfigService.java
@@ -189,7 +189,7 @@ public class MockGenericConfigService {
                       currentValues.get(
                           ResourceType.of(
                               request.getResourceNamespace(), request.getResourceName()),
-                          request.getContext()));
+                          configContextOrDefault(request.getContext())));
               currentValues.remove(
                   ResourceType.of(request.getResourceNamespace(), request.getResourceName()),
                   configContextOrDefault(request.getContext()));


### PR DESCRIPTION
## Description
This PR fixes a bug in mockDelete. While we default to default config context if there is no config context while removing an item, we do not do so while verifying if the item is present just before it. This is resulting in a false `NOT_FOUND` error in case of context being absent.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
