### PR TITLE
chore: use document store bulk upsert

### DIFF
--- a/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/ConfigServiceGrpcImplTest.java
@@ -39,7 +39,7 @@ import org.hypertrace.config.service.v1.GetConfigResponse;
 import org.hypertrace.config.service.v1.UpsertAllConfigsResponse.UpsertedConfig;
 import org.hypertrace.config.service.v1.UpsertConfigRequest;
 import org.hypertrace.config.service.v1.UpsertConfigResponse;
-import org.hypertrace.core.grpcutils.client.GrpcClientRequestContextUtil;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -73,14 +73,14 @@ class ConfigServiceGrpcImplTest {
         () -> configServiceGrpc.upsertConfig(getUpsertConfigRequest("", config1), responseObserver);
     Runnable runnableWithoutContext2 =
         () -> configServiceGrpc.upsertConfig(getUpsertConfigRequest("", config2), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnableWithoutContext1);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnableWithoutContext2);
+    RequestContext.forTenantId(TENANT_ID).run(runnableWithoutContext1);
+    RequestContext.forTenantId(TENANT_ID).run(runnableWithoutContext2);
 
     Runnable runnableWithContext =
         () ->
             configServiceGrpc.upsertConfig(
                 getUpsertConfigRequest(CONTEXT1, config2), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnableWithContext);
+    RequestContext.forTenantId(TENANT_ID).run(runnableWithContext);
 
     ArgumentCaptor<UpsertConfigResponse> upsertConfigResponseCaptor =
         ArgumentCaptor.forClass(UpsertConfigResponse.class);
@@ -119,11 +119,11 @@ class ConfigServiceGrpcImplTest {
 
     Runnable runnableWithoutContext =
         () -> configServiceGrpc.getConfig(getGetConfigRequest(), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnableWithoutContext);
+    RequestContext.forTenantId(TENANT_ID).run(runnableWithoutContext);
 
     Runnable runnableWithContext =
         () -> configServiceGrpc.getConfig(getGetConfigRequest(CONTEXT1), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnableWithContext);
+    RequestContext.forTenantId(TENANT_ID).run(runnableWithContext);
 
     ArgumentCaptor<GetConfigResponse> getConfigResponseCaptor =
         ArgumentCaptor.forClass(GetConfigResponse.class);
@@ -164,7 +164,7 @@ class ConfigServiceGrpcImplTest {
 
     Runnable runnable =
         () -> configServiceGrpc.getAllConfigs(getGetAllConfigsRequest(), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnable);
+    RequestContext.forTenantId(TENANT_ID).run(runnable);
 
     ArgumentCaptor<GetAllConfigsResponse> getAllConfigsResponseCaptor =
         ArgumentCaptor.forClass(GetAllConfigsResponse.class);
@@ -187,7 +187,7 @@ class ConfigServiceGrpcImplTest {
 
     Runnable runnable =
         () -> configServiceGrpc.deleteConfig(getDeleteConfigRequest(), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnable);
+    RequestContext.forTenantId(TENANT_ID).run(runnable);
 
     verify(configStore, times(1))
         .writeConfig(eq(configResourceWithContext), eq(""), eq(emptyValue()));
@@ -210,7 +210,7 @@ class ConfigServiceGrpcImplTest {
         () ->
             configServiceGrpc.deleteConfig(
                 getDefaultContextDeleteConfigRequest(), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnable);
+    RequestContext.forTenantId(TENANT_ID).run(runnable);
 
     verify(configStore, times(1))
         .writeConfig(eq(configResourceWithoutContext), eq(""), eq(emptyValue()));
@@ -230,7 +230,7 @@ class ConfigServiceGrpcImplTest {
 
     Runnable runnable =
         () -> configServiceGrpc.deleteConfig(getDeleteConfigRequest(), responseObserver);
-    GrpcClientRequestContextUtil.executeInTenantContext(TENANT_ID, runnable);
+    RequestContext.forTenantId(TENANT_ID).run(runnable);
 
     ArgumentCaptor<Throwable> throwableArgumentCaptor = ArgumentCaptor.forClass(Throwable.class);
     verify(responseObserver, times(1)).onError(throwableArgumentCaptor.capture());

--- a/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
+++ b/config-service-impl/src/test/java/org/hypertrace/config/service/store/DocumentConfigStoreTest.java
@@ -11,7 +11,6 @@ import static org.hypertrace.config.service.store.DocumentConfigStore.CONFIGURAT
 import static org.hypertrace.config.service.store.DocumentConfigStore.DATA_STORE_TYPE;
 import static org.hypertrace.config.service.store.DocumentConfigStore.DOC_STORE_CONFIG_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -183,25 +182,23 @@ class DocumentConfigStoreTest {
         configStore.writeAllConfigs(
             ImmutableMap.of(resourceContext1, config2, resourceContext2, config1), USER_ID);
 
-    assertEquals(2, upsertedConfigs.size());
-    assertTrue(
-        upsertedConfigs.contains(
+    assertEquals(
+        List.of(
             UpsertedConfig.newBuilder()
                 .setContext(resourceContext1.getContext())
                 .setCreationTimestamp(TIMESTAMP1)
                 .setUpdateTimestamp(updateTime)
                 .setConfig(config2)
                 .setPrevConfig(config1)
-                .build()));
-    assertTrue(
-        upsertedConfigs.contains(
+                .build(),
             UpsertedConfig.newBuilder()
                 .setContext(resourceContext2.getContext())
                 .setCreationTimestamp(TIMESTAMP2)
                 .setUpdateTimestamp(updateTime)
                 .setConfig(config1)
                 .setPrevConfig(config2)
-                .build()));
+                .build()),
+        upsertedConfigs);
 
     verify(collection, times(1))
         .bulkUpsert(

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -55,7 +55,6 @@ tasks.integrationTest {
 }
 
 dependencies {
-  implementation(libs.hypertrace.grpcutils.context)
   implementation(libs.hypertrace.grpc.framework)
   implementation(projects.configServiceFactory)
 
@@ -69,6 +68,7 @@ dependencies {
   integrationTestImplementation(libs.snakeyaml)
   integrationTestImplementation(libs.hypertrace.framework.integrationtest)
   integrationTestImplementation(libs.hypertrace.grpcutils.client)
+  integrationTestImplementation(libs.hypertrace.grpcutils.context)
   integrationTestImplementation(libs.hypertrace.documentstore)
 }
 

--- a/config-service/build.gradle.kts
+++ b/config-service/build.gradle.kts
@@ -55,6 +55,7 @@ tasks.integrationTest {
 }
 
 dependencies {
+  implementation(libs.hypertrace.grpcutils.context)
   implementation(libs.hypertrace.grpc.framework)
   implementation(projects.configServiceFactory)
 

--- a/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
+++ b/config-service/src/integrationTest/java/org/hypertrace/config/service/ConfigServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.config.service;
 
 import static org.hypertrace.config.service.IntegrationTestUtils.getConfigValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.Value;
@@ -24,6 +25,9 @@ import org.hypertrace.config.service.v1.GetAllConfigsRequest;
 import org.hypertrace.config.service.v1.GetAllConfigsResponse;
 import org.hypertrace.config.service.v1.GetConfigRequest;
 import org.hypertrace.config.service.v1.GetConfigResponse;
+import org.hypertrace.config.service.v1.UpsertAllConfigsRequest;
+import org.hypertrace.config.service.v1.UpsertAllConfigsRequest.ConfigToUpsert;
+import org.hypertrace.config.service.v1.UpsertAllConfigsResponse;
 import org.hypertrace.config.service.v1.UpsertConfigRequest;
 import org.hypertrace.config.service.v1.UpsertConfigResponse;
 import org.hypertrace.core.documentstore.Collection;
@@ -31,6 +35,7 @@ import org.hypertrace.core.documentstore.Datastore;
 import org.hypertrace.core.documentstore.DatastoreProvider;
 import org.hypertrace.core.grpcutils.client.GrpcClientRequestContextUtil;
 import org.hypertrace.core.grpcutils.client.RequestContextClientCallCredsProviderFactory;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.core.serviceframework.IntegrationTestServerUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -98,6 +103,49 @@ public class ConfigServiceIntegrationTest {
     upsertConfigResponse =
         upsertConfig(RESOURCE_NAME, RESOURCE_NAMESPACE, TENANT_2, Optional.empty(), config1);
     assertEquals(config1, upsertConfigResponse.getConfig());
+  }
+
+  @Test
+  public void testUpsertAllConfigs() {
+    String context1 = "context1";
+    String context2 = "context2";
+    UpsertAllConfigsRequest upsertAllConfigsRequest =
+        UpsertAllConfigsRequest.newBuilder()
+            .addAllConfigs(
+                List.of(
+                    buildConfigToUpsert(context1, config1), buildConfigToUpsert(context2, config2)))
+            .build();
+    UpsertAllConfigsResponse upsertAllConfigsResponse =
+        upsertConfigs(upsertAllConfigsRequest, TENANT_1);
+    assertEquals(2, upsertAllConfigsResponse.getUpsertedConfigsCount());
+    UpsertAllConfigsResponse.UpsertedConfig upsertedConfig1 =
+        upsertAllConfigsResponse.getUpsertedConfigs(1);
+    assertEquals(context1, upsertedConfig1.getContext());
+    assertEquals(config1, upsertedConfig1.getConfig());
+    assertFalse(upsertedConfig1.hasPrevConfig());
+    UpsertAllConfigsResponse.UpsertedConfig upsertedConfig2 =
+        upsertAllConfigsResponse.getUpsertedConfigs(0);
+    assertEquals(context2, upsertedConfig2.getContext());
+    assertEquals(config2, upsertedConfig2.getConfig());
+    assertFalse(upsertedConfig2.hasPrevConfig());
+
+    // Swap configs between contexts as an update
+    upsertAllConfigsRequest =
+        UpsertAllConfigsRequest.newBuilder()
+            .addAllConfigs(
+                List.of(
+                    buildConfigToUpsert(context1, config2), buildConfigToUpsert(context2, config1)))
+            .build();
+    upsertAllConfigsResponse = upsertConfigs(upsertAllConfigsRequest, TENANT_1);
+    assertEquals(2, upsertAllConfigsResponse.getUpsertedConfigsCount());
+    upsertedConfig1 = upsertAllConfigsResponse.getUpsertedConfigs(0);
+    assertEquals(context2, upsertedConfig1.getContext());
+    assertEquals(config1, upsertedConfig1.getConfig());
+    assertEquals(config2, upsertedConfig1.getPrevConfig());
+    upsertedConfig2 = upsertAllConfigsResponse.getUpsertedConfigs(1);
+    assertEquals(context1, upsertedConfig2.getContext());
+    assertEquals(config2, upsertedConfig2.getConfig());
+    assertEquals(config1, upsertedConfig2.getPrevConfig());
   }
 
   @Test
@@ -202,6 +250,21 @@ public class ConfigServiceIntegrationTest {
     }
     return GrpcClientRequestContextUtil.executeInTenantContext(
         tenantId, () -> configServiceBlockingStub.upsertConfig(builder.build()));
+  }
+
+  private UpsertAllConfigsResponse upsertConfigs(
+      UpsertAllConfigsRequest upsertAllConfigsRequest, String tenantId) {
+    return RequestContext.forTenantId(tenantId)
+        .call(() -> configServiceBlockingStub.upsertAllConfigs(upsertAllConfigsRequest));
+  }
+
+  private ConfigToUpsert buildConfigToUpsert(String context, Value config) {
+    return ConfigToUpsert.newBuilder()
+        .setResourceName(RESOURCE_NAME)
+        .setResourceNamespace(RESOURCE_NAMESPACE)
+        .setContext(context)
+        .setConfig(config)
+        .build();
   }
 
   private GetConfigResponse getConfig(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ hypertrace-grpc-framework = { module = "org.hypertrace.core.serviceframework:pla
 hypertrace-framework-metrics = { module = "org.hypertrace.core.serviceframework:platform-service-framework", version.ref = "hypertrace-framework" }
 hypertrace-framework-integrationtest = { module = "org.hypertrace.core.serviceframework:integrationtest-service-framework", version.ref = "hypertrace-framework" }
 
-hypertrace-documentstore = { module = "org.hypertrace.core.documentstore:document-store", version = "0.7.5" }
+hypertrace-documentstore = { module = "org.hypertrace.core.documentstore:document-store", version = "0.7.23" }
 hypertrace-eventstore = { module = "org.hypertrace.core.eventstore:event-store", version = "0.1.2" }
 
 guava = { module = "com.google.guava:guava", version = "31.1-jre" }


### PR DESCRIPTION
## Description
This PR refactors upsertAllConfigs API impl to use bulk upsert document store method

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests and integration test to successfully verify the changes

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
