### PR TITLE
fix: query filter bug

### DIFF
--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -208,14 +208,22 @@ public class DocumentConfigStore implements ConfigStore {
 
   private Map<ConfigResourceContext, Optional<ConfigDocument>> getLatestVersionConfigDocs(
       Set<ConfigResourceContext> configResourceContexts) throws IOException {
+    if (configResourceContexts.isEmpty()) {
+      return Collections.emptyMap();
+    }
     // build filter
     List<Filter> childFilters =
         configResourceContexts.stream()
-            .map(this::getConfigResourceContextFilter)
+            .map(this::getConfigResourceFieldContextFilter)
             .collect(Collectors.toUnmodifiableList());
-    Filter filter = new Filter();
-    filter.setOp(Filter.Op.OR);
-    filter.setChildFilters(childFilters.toArray(Filter[]::new));
+    Filter configResourceFieldContextFilter = new Filter();
+    configResourceFieldContextFilter.setOp(Filter.Op.OR);
+    configResourceFieldContextFilter.setChildFilters(childFilters.toArray(Filter[]::new));
+    Filter tenantIdFilter =
+        Filter.eq(
+            TENANT_ID_FIELD_NAME,
+            configResourceContexts.iterator().next().getConfigResource().getTenantId());
+    Filter filter = new Filter().and(tenantIdFilter, configResourceFieldContextFilter);
 
     // build query
     Query query = new Query();
@@ -243,6 +251,13 @@ public class DocumentConfigStore implements ConfigStore {
 
   private Filter getConfigResourceContextFilter(ConfigResourceContext configResourceContext) {
     return this.getConfigResourceFilter(configResourceContext.getConfigResource())
+        .and(Filter.eq(CONTEXT_FIELD_NAME, configResourceContext.getContext()));
+  }
+
+  private Filter getConfigResourceFieldContextFilter(ConfigResourceContext configResourceContext) {
+    ConfigResource configResource = configResourceContext.getConfigResource();
+    return Filter.eq(RESOURCE_FIELD_NAME, configResource.getResourceName())
+        .and(Filter.eq(RESOURCE_NAMESPACE_FIELD_NAME, configResource.getResourceNamespace()))
         .and(Filter.eq(CONTEXT_FIELD_NAME, configResourceContext.getContext()));
   }
 

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -223,7 +223,7 @@ public class DocumentConfigStore implements ConfigStore {
         Filter.eq(
             TENANT_ID_FIELD_NAME,
             configResourceContexts.iterator().next().getConfigResource().getTenantId());
-    Filter filter = new Filter().and(tenantIdFilter, configResourceFieldContextFilter);
+    Filter filter = tenantIdFilter.and(configResourceFieldContextFilter);
 
     // build query
     Query query = new Query();


### PR DESCRIPTION
## Description
This PR fixes a bug in the query filter. When we provide no configs to bulk update, the query filter default to an empty OR. This fetches all the configs throughout. We set a limit on the query response to 0 in such cases. But a limit of 0 on mongo is equivalent to no limit.  On update, all these are being set to null as it can't find the values to assign to it as they are not part of the request. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
