### PR TITLE
fix: disallow empty providing config list to bulk upsert 

### DIFF
--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
@@ -144,6 +144,10 @@ public class ConfigServiceGrpcImpl extends ConfigServiceGrpc.ConfigServiceImplBa
   public void upsertAllConfigs(
       UpsertAllConfigsRequest request, StreamObserver<UpsertAllConfigsResponse> responseObserver) {
     try {
+      if (request.getConfigsCount() == 0) {
+        responseObserver.onError(Status.INVALID_ARGUMENT.asException());
+        return;
+      }
       Map<ConfigResourceContext, Value> valuesByContext =
           request.getConfigsList().stream()
               .map(

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/ConfigServiceGrpcImpl.java
@@ -145,7 +145,10 @@ public class ConfigServiceGrpcImpl extends ConfigServiceGrpc.ConfigServiceImplBa
       UpsertAllConfigsRequest request, StreamObserver<UpsertAllConfigsResponse> responseObserver) {
     try {
       if (request.getConfigsCount() == 0) {
-        responseObserver.onError(Status.INVALID_ARGUMENT.asException());
+        responseObserver.onError(
+            Status.INVALID_ARGUMENT
+                .withDescription("List of configs to upsert provided is empty")
+                .asException());
         return;
       }
       Map<ConfigResourceContext, Value> valuesByContext =

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -10,6 +10,7 @@ import static org.hypertrace.config.service.store.ConfigDocument.VERSION_FIELD_N
 
 import com.google.protobuf.Value;
 import com.typesafe.config.Config;
+import io.grpc.Status;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -95,10 +96,14 @@ public class DocumentConfigStore implements ConfigStore {
         getLatestVersionConfigDocs(resourceContextValueMap.keySet());
     Map<Key, Document> documentsToBeUpserted = new LinkedHashMap<>();
     previousConfigDocs.forEach(
-        (key, value) ->
-            documentsToBeUpserted.put(
-                new ConfigDocumentKey(key),
-                buildConfigDocument(key, resourceContextValueMap.get(key), userId, value)));
+        (key, value) -> {
+          if (!resourceContextValueMap.containsKey(key)) {
+            throw Status.INVALID_ARGUMENT.asRuntimeException();
+          }
+          documentsToBeUpserted.put(
+              new ConfigDocumentKey(key),
+              buildConfigDocument(key, resourceContextValueMap.get(key), userId, value));
+        });
 
     boolean successfulBulkUpsertDocuments = collection.bulkUpsert(documentsToBeUpserted);
     if (successfulBulkUpsertDocuments) {

--- a/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
+++ b/config-service-impl/src/main/java/org/hypertrace/config/service/store/DocumentConfigStore.java
@@ -98,7 +98,7 @@ public class DocumentConfigStore implements ConfigStore {
     previousConfigDocs.forEach(
         (key, value) -> {
           if (!resourceContextValueMap.containsKey(key)) {
-            throw Status.INVALID_ARGUMENT.asRuntimeException();
+            throw Status.INTERNAL.asRuntimeException();
           }
           documentsToBeUpserted.put(
               new ConfigDocumentKey(key),


### PR DESCRIPTION
## Description
This PR adds a check to disallow providing empty config list to bulk upsert.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
