### PR TITLE
Add support for default profiles creation for partitioner config service

### DIFF
--- a/helm/templates/config-service-config.yaml
+++ b/helm/templates/config-service-config.yaml
@@ -31,3 +31,10 @@ data:
         schema.registry.url = "http://schema-registry-service:8081"
       }
     }
+
+    partition.config.service {
+      members = {{ toJson .Values.partitionServiceConfig.default.profile.names }}
+      weight = {{ .Values.partitionServiceConfig.default.profile.weight }}
+      partition.key = {{ .Values.partitionServiceConfig.default.profile.partition.key }}
+    }
+

--- a/helm/templates/config-service-config.yaml
+++ b/helm/templates/config-service-config.yaml
@@ -31,14 +31,13 @@ data:
         schema.registry.url = "http://schema-registry-service:8081"
       }
     }
-
     partitioner.config.service {
-      {{- if $.Values.partitionerServiceConfig.default.profiles }}
+      {{- if $.Values.partitionerServiceConfig.defaultProfiles }}
       default.profiles = [
-      {{- range $k,$v := $.Values.partitionerServiceConfig.default.profiles }}
+      {{- range $k,$v := $.Values.partitionerServiceConfig.defaultProfiles }}
         {
           name = {{ $v.name }}
-          partitionkey = {{ $v.partitionkey }}
+          partition.key = {{ $v.partitionKey }}
         }
       {{- end }}
       {{- end }}

--- a/helm/templates/config-service-config.yaml
+++ b/helm/templates/config-service-config.yaml
@@ -32,9 +32,16 @@ data:
       }
     }
 
-    partition.config.service {
-      members = {{ toJson .Values.partitionServiceConfig.default.profile.names }}
-      weight = {{ .Values.partitionServiceConfig.default.profile.weight }}
-      partition.key = {{ .Values.partitionServiceConfig.default.profile.partition.key }}
+    partitioner.config.service {
+      {{- if $.Values.partitionerServiceConfig.default.profiles }}
+      default.profiles = [
+      {{- range $k,$v := $.Values.partitionerServiceConfig.default.profiles }}
+        {
+          name = {{ $v.name }}
+          partitionkey = {{ $v.partitionkey }}
+        }
+      {{- end }}
+      {{- end }}
+      ]
     }
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,6 +85,13 @@ configServiceConfig:
     host: mongo
     url: ""
 
+partitionServiceConfig:
+  default:
+    profile:
+      names: []
+      weight: 100
+      partition.key: ""
+
 logConfig:
   name: config-service-log-config
   monitorInterval: 30

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -86,9 +86,9 @@ configServiceConfig:
     url: ""
 
 partitionerServiceConfig:
-  default.profiles:
+  defaultProfiles:
     - name: "spans"
-      partitionkey: "customer_id"
+      partitionKey: "customer_id"
 
 logConfig:
   name: config-service-log-config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,12 +85,10 @@ configServiceConfig:
     host: mongo
     url: ""
 
-partitionServiceConfig:
-  default:
-    profile:
-      names: []
-      weight: 100
-      partition.key: ""
+partitionerServiceConfig:
+  default.profiles:
+    - name: "spans"
+      partitionkey: "customer_id"
 
 logConfig:
   name: config-service-log-config

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
@@ -13,8 +13,7 @@ public class PartitionerConfigServiceModule extends AbstractModule {
   public static final String GENERIC_CONFIG_SERVICE = "generic.config.service";
   public static final String DOC_STORE_CONFIG_KEY = "document.store";
   public static final String DATA_STORE_TYPE = "dataStoreType";
-
-  public static final String DEFAULT_PROFILE = "partition.config.service";
+  public static final String DEFAULT_PROFILE = "partitioner.config.service";
 
   private final Config config;
 
@@ -25,12 +24,12 @@ public class PartitionerConfigServiceModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(BindableService.class).to(PartitionerConfigServiceImpl.class);
-    bind(PartitionerProfilesStore.class)
-        .toInstance(getDocumentStore(config.getConfig(GENERIC_CONFIG_SERVICE)));
+    bind(PartitionerProfilesStore.class).toInstance(getDocumentStore(config));
   }
 
   private PartitionerProfilesDocumentStore getDocumentStore(Config config) {
-    Config docStoreConfig = config.getConfig(DOC_STORE_CONFIG_KEY);
+    Config genericConfig = config.getConfig(GENERIC_CONFIG_SERVICE);
+    Config docStoreConfig = genericConfig.getConfig(DOC_STORE_CONFIG_KEY);
     String dataStoreType = docStoreConfig.getString(DATA_STORE_TYPE);
     Config dataStoreConfig = docStoreConfig.getConfig(dataStoreType);
     Config defaultProfileConfig = config.getConfig(DEFAULT_PROFILE);

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
@@ -14,6 +14,8 @@ public class PartitionerConfigServiceModule extends AbstractModule {
   public static final String DOC_STORE_CONFIG_KEY = "document.store";
   public static final String DATA_STORE_TYPE = "dataStoreType";
 
+  public static final String DEFAULT_PROFILE = "partition.config.service";
+
   private final Config config;
 
   public PartitionerConfigServiceModule(Config config) {
@@ -31,7 +33,8 @@ public class PartitionerConfigServiceModule extends AbstractModule {
     Config docStoreConfig = config.getConfig(DOC_STORE_CONFIG_KEY);
     String dataStoreType = docStoreConfig.getString(DATA_STORE_TYPE);
     Config dataStoreConfig = docStoreConfig.getConfig(dataStoreType);
+    Config defaultProfileConfig = config.getConfig(DEFAULT_PROFILE);
     Datastore datastore = DatastoreProvider.getDatastore(dataStoreType, dataStoreConfig);
-    return new PartitionerProfilesDocumentStore(datastore);
+    return new PartitionerProfilesDocumentStore(datastore, defaultProfileConfig);
   }
 }

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceModule.java
@@ -13,7 +13,7 @@ public class PartitionerConfigServiceModule extends AbstractModule {
   public static final String GENERIC_CONFIG_SERVICE = "generic.config.service";
   public static final String DOC_STORE_CONFIG_KEY = "document.store";
   public static final String DATA_STORE_TYPE = "dataStoreType";
-  public static final String DEFAULT_PROFILE = "partitioner.config.service";
+  public static final String PARTITIONER_CONFIG_SERVICE = "partitioner.config.service";
 
   private final Config config;
 
@@ -32,8 +32,8 @@ public class PartitionerConfigServiceModule extends AbstractModule {
     Config docStoreConfig = genericConfig.getConfig(DOC_STORE_CONFIG_KEY);
     String dataStoreType = docStoreConfig.getString(DATA_STORE_TYPE);
     Config dataStoreConfig = docStoreConfig.getConfig(dataStoreType);
-    Config defaultProfileConfig = config.getConfig(DEFAULT_PROFILE);
+    Config partitionerConfig = config.getConfig(PARTITIONER_CONFIG_SERVICE);
     Datastore datastore = DatastoreProvider.getDatastore(dataStoreType, dataStoreConfig);
-    return new PartitionerProfilesDocumentStore(datastore, defaultProfileConfig);
+    return new PartitionerProfilesDocumentStore(datastore, partitionerConfig);
   }
 }

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidator.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidator.java
@@ -37,11 +37,11 @@ public class PartitionerConfigServiceRequestValidator {
                     .withDescription("partition key cannot be empty")
                     .asRuntimeException();
               }
-              if (profile.getGroupsCount() == 0) {
-                throw Status.INVALID_ARGUMENT
-                    .withDescription("partition_groups cannot be empty")
-                    .asRuntimeException();
-              }
+//              if (profile.getGroupsCount() == 0) {
+//                throw Status.INVALID_ARGUMENT
+//                    .withDescription("partition_groups cannot be empty")
+//                    .asRuntimeException();
+//              }
               profile
                   .getGroupsList()
                   .forEach(

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidator.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidator.java
@@ -37,11 +37,6 @@ public class PartitionerConfigServiceRequestValidator {
                     .withDescription("partition key cannot be empty")
                     .asRuntimeException();
               }
-//              if (profile.getGroupsCount() == 0) {
-//                throw Status.INVALID_ARGUMENT
-//                    .withDescription("partition_groups cannot be empty")
-//                    .asRuntimeException();
-//              }
               profile
                   .getGroupsList()
                   .forEach(

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
@@ -5,7 +5,6 @@ import com.typesafe.config.Config;
 import io.grpc.Status;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import lombok.SneakyThrows;
 import org.hypertrace.core.documentstore.*;
 import org.hypertrace.core.documentstore.Collection;
@@ -75,17 +74,16 @@ public class PartitionerProfilesDocumentStore implements PartitionerProfilesStor
   @SneakyThrows
   private void setUpDefaultProfile(Config partitionerConfig) {
     ArrayList<PartitionerProfile> partitionerProfiles = new ArrayList<>();
-    for (Config profile : partitionerConfig
-            .getConfigList(DEFAULT_PROFILES)) {
+    for (Config profile : partitionerConfig.getConfigList(DEFAULT_PROFILES)) {
       Optional<PartitionerProfile> fetchedProfile =
-              getPartitionerProfile(profile.getString(PROFILE_NAME));
+          getPartitionerProfile(profile.getString(PROFILE_NAME));
       if (fetchedProfile.isEmpty()) {
         PartitionerProfile newProfile =
-                PartitionerProfile.newBuilder()
-                        .setName(profile.getString(PROFILE_NAME))
-                        .setDefaultGroupWeight(DEFAULT_PROFILE_WEIGHT)
-                        .setPartitionKey(profile.getString(PROFILE_PARTITION_KEY))
-                        .build();
+            PartitionerProfile.newBuilder()
+                .setName(profile.getString(PROFILE_NAME))
+                .setDefaultGroupWeight(DEFAULT_PROFILE_WEIGHT)
+                .setPartitionKey(profile.getString(PROFILE_PARTITION_KEY))
+                .build();
         partitionerProfiles.add(newProfile);
         putPartitionerProfiles(partitionerProfiles);
       }

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
@@ -5,6 +5,8 @@ import com.typesafe.config.Config;
 import io.grpc.Status;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
 import org.hypertrace.core.documentstore.*;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.partitioner.config.service.v1.PartitionerProfile;
@@ -70,28 +72,23 @@ public class PartitionerProfilesDocumentStore implements PartitionerProfilesStor
         profiles.stream().map(PartitionerProfileKey::new).collect(Collectors.toSet()));
   }
 
+  @SneakyThrows
   private void setUpDefaultProfile(Config partitionerConfig) {
     ArrayList<PartitionerProfile> partitionerProfiles = new ArrayList<>();
-    partitionerConfig
-        .getConfigList(DEFAULT_PROFILES)
-        .forEach(
-            profile -> {
-              try {
-                Optional<PartitionerProfile> fetchedProfile =
-                    getPartitionerProfile(profile.getString(PROFILE_NAME));
-                if (fetchedProfile.isEmpty()) {
-                  PartitionerProfile newProfile =
-                      PartitionerProfile.newBuilder()
-                          .setName(profile.getString(PROFILE_NAME))
-                          .setDefaultGroupWeight(DEFAULT_PROFILE_WEIGHT)
-                          .setPartitionKey(profile.getString(PROFILE_PARTITION_KEY))
-                          .build();
-                  partitionerProfiles.add(newProfile);
-                  putPartitionerProfiles(partitionerProfiles);
-                }
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-            });
+    for (Config profile : partitionerConfig
+            .getConfigList(DEFAULT_PROFILES)) {
+      Optional<PartitionerProfile> fetchedProfile =
+              getPartitionerProfile(profile.getString(PROFILE_NAME));
+      if (fetchedProfile.isEmpty()) {
+        PartitionerProfile newProfile =
+                PartitionerProfile.newBuilder()
+                        .setName(profile.getString(PROFILE_NAME))
+                        .setDefaultGroupWeight(DEFAULT_PROFILE_WEIGHT)
+                        .setPartitionKey(profile.getString(PROFILE_PARTITION_KEY))
+                        .build();
+        partitionerProfiles.add(newProfile);
+        putPartitionerProfiles(partitionerProfiles);
+      }
+    }
   }
 }

--- a/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
+++ b/partitioner-config-service-impl/src/main/java/org/hypertrace/partitioner/config/service/store/PartitionerProfilesDocumentStore.java
@@ -12,15 +12,15 @@ import org.hypertrace.partitioner.config.service.v1.PartitionerProfile;
 public class PartitionerProfilesDocumentStore implements PartitionerProfilesStore {
   public static final String PARTITIONER_PROFILES = "partitioner_profiles";
   private static final String PARTITIONER_PROFILE_NAME_FIELD = "name";
-  private static final String DEFAULT_PROFILES_FIELD = "default.profiles";
-  private static final String DEFAULT_PROFILE_NAME = "name";
-  private static final String DEFAULT_PROFILE_PARTITION_KEY = "partitionkey";
+  private static final String DEFAULT_PROFILES = "default.profiles";
+  private static final String PROFILE_NAME = "name";
+  private static final String PROFILE_PARTITION_KEY = "partition.key";
   private static final int DEFAULT_PROFILE_WEIGHT = 100;
   private final Collection collection;
 
-  public PartitionerProfilesDocumentStore(Datastore datastore, Config defaultProfile) {
+  public PartitionerProfilesDocumentStore(Datastore datastore, Config partitionerConfig) {
     this.collection = datastore.getCollection(PARTITIONER_PROFILES);
-    setUpDefaultProfile(defaultProfile);
+    setUpDefaultProfile(partitionerConfig);
   }
 
   @Override
@@ -70,21 +70,21 @@ public class PartitionerProfilesDocumentStore implements PartitionerProfilesStor
         profiles.stream().map(PartitionerProfileKey::new).collect(Collectors.toSet()));
   }
 
-  private void setUpDefaultProfile(Config defaultProfile) {
+  private void setUpDefaultProfile(Config partitionerConfig) {
     ArrayList<PartitionerProfile> partitionerProfiles = new ArrayList<>();
-    defaultProfile
-        .getConfigList(DEFAULT_PROFILES_FIELD)
+    partitionerConfig
+        .getConfigList(DEFAULT_PROFILES)
         .forEach(
             profile -> {
               try {
                 Optional<PartitionerProfile> fetchedProfile =
-                    getPartitionerProfile(profile.getString(DEFAULT_PROFILE_NAME));
+                    getPartitionerProfile(profile.getString(PROFILE_NAME));
                 if (fetchedProfile.isEmpty()) {
                   PartitionerProfile newProfile =
                       PartitionerProfile.newBuilder()
-                          .setName(profile.getString(DEFAULT_PROFILE_NAME))
+                          .setName(profile.getString(PROFILE_NAME))
                           .setDefaultGroupWeight(DEFAULT_PROFILE_WEIGHT)
-                          .setPartitionKey(profile.getString(DEFAULT_PROFILE_PARTITION_KEY))
+                          .setPartitionKey(profile.getString(PROFILE_PARTITION_KEY))
                           .build();
                   partitionerProfiles.add(newProfile);
                   putPartitionerProfiles(partitionerProfiles);

--- a/partitioner-config-service-impl/src/test/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidatorTest.java
+++ b/partitioner-config-service-impl/src/test/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidatorTest.java
@@ -56,10 +56,7 @@ class PartitionerConfigServiceRequestValidatorTest {
   public void testPartitionGroupsExist() {
     PartitionerConfigServiceRequestValidator underTest =
         new PartitionerConfigServiceRequestValidator();
-
-    Exception exception =
-        assertThrows(
-            RuntimeException.class,
+assertDoesNotThrow(
             () ->
                 underTest.validateOrThrow(
                     PutPartitionerProfilesRequest.newBuilder()

--- a/partitioner-config-service-impl/src/test/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidatorTest.java
+++ b/partitioner-config-service-impl/src/test/java/org/hypertrace/partitioner/config/service/PartitionerConfigServiceRequestValidatorTest.java
@@ -56,17 +56,17 @@ class PartitionerConfigServiceRequestValidatorTest {
   public void testPartitionGroupsExist() {
     PartitionerConfigServiceRequestValidator underTest =
         new PartitionerConfigServiceRequestValidator();
-assertDoesNotThrow(
-            () ->
-                underTest.validateOrThrow(
-                    PutPartitionerProfilesRequest.newBuilder()
-                        .addProfiles(
-                            PartitionerProfile.newBuilder()
-                                .setName("spansCountProfile")
-                                .setDefaultGroupWeight(25)
-                                .setPartitionKey("tenant_id")
-                                .build())
-                        .build()));
+    assertDoesNotThrow(
+        () ->
+            underTest.validateOrThrow(
+                PutPartitionerProfilesRequest.newBuilder()
+                    .addProfiles(
+                        PartitionerProfile.newBuilder()
+                            .setName("spansCountProfile")
+                            .setDefaultGroupWeight(25)
+                            .setPartitionKey("tenant_id")
+                            .build())
+                    .build()));
   }
 
   @Test


### PR DESCRIPTION
## Description
Adding support to create default partitioner profiles if they don't exist on service start up 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
