### PR TITLE
Add webhook domain exclusion config for notification channels

### DIFF
--- a/alerting-config-service-api/build.gradle.kts
+++ b/alerting-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/config-proto-converter/build.gradle.kts
+++ b/config-proto-converter/build.gradle.kts
@@ -11,4 +11,9 @@ dependencies {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
     }
   }
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }

--- a/config-service-api/build.gradle.kts
+++ b/config-service-api/build.gradle.kts
@@ -73,4 +73,9 @@ dependencies {
   testFixturesImplementation(libs.guava)
   testFixturesAnnotationProcessor(libs.lombok)
   testFixturesCompileOnly(libs.lombok)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }

--- a/config-service-factory/src/main/java/org/hypertrace/config/service/ConfigServiceFactory.java
+++ b/config-service-factory/src/main/java/org/hypertrace/config/service/ConfigServiceFactory.java
@@ -65,7 +65,8 @@ public class ConfigServiceFactory implements GrpcPlatformServiceFactory {
                 localChannel, config, configChangeEventGenerator),
             new EventConditionConfigServiceImpl(localChannel, configChangeEventGenerator),
             new NotificationRuleConfigServiceImpl(localChannel, configChangeEventGenerator),
-            new NotificationChannelConfigServiceImpl(localChannel, configChangeEventGenerator),
+            new NotificationChannelConfigServiceImpl(
+                localChannel, config, configChangeEventGenerator),
             SpanProcessingConfigServiceFactory.build(localChannel, config))
         .map(GrpcPlatformService::new)
         .collect(Collectors.toUnmodifiableList());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-protoc = "3.21.12"
-grpc = "1.56.0"
+protoc = "3.23.2"
+grpc = "1.56.1"
 gson = "2.9.0"
 hypertrace-grpcutils = "0.12.1"
 hypertrace-framework = "0.1.52"

--- a/label-application-rule-config-service-api/build.gradle.kts
+++ b/label-application-rule-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/labels-config-service-api/build.gradle.kts
+++ b/labels-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/notification-channel-config-service-api/build.gradle.kts
+++ b/notification-channel-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/notification-channel-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceImplTest.java
+++ b/notification-channel-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
+import com.typesafe.config.Config;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,7 +39,7 @@ class NotificationChannelConfigServiceImplTest {
     mockGenericConfigService
         .addService(
             new NotificationChannelConfigServiceImpl(
-                mockGenericConfigService.channel(), configChangeEventGenerator))
+                mockGenericConfigService.channel(), mock(Config.class), configChangeEventGenerator))
         .start();
 
     channelStub =

--- a/notification-channel-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceRequestValidatorTest.java
+++ b/notification-channel-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationChannelConfigServiceRequestValidatorTest.java
@@ -1,0 +1,91 @@
+package org.hypertrace.notification.config.service;
+
+import static org.hypertrace.notification.config.service.NotificationChannelConfigServiceImpl.NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.File;
+import org.hypertrace.notification.config.service.v1.NotificationChannelMutableData;
+import org.hypertrace.notification.config.service.v1.WebhookChannelConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NotificationChannelConfigServiceRequestValidatorTest {
+  @Test
+  public void testValidateWebhookExclusions() {
+    NotificationChannelConfigServiceRequestValidator
+        notificationChannelConfigServiceRequestValidator =
+            new NotificationChannelConfigServiceRequestValidator();
+    File configFile = new File(ClassLoader.getSystemResource("application.conf").getPath());
+    Config config = ConfigFactory.parseFile(configFile);
+    NotificationChannelMutableData notificationChannelMutableDataWithExcludedDomain =
+        NotificationChannelMutableData.newBuilder()
+            .setChannelName("testChannel")
+            .addWebhookChannelConfig(
+                WebhookChannelConfig.newBuilder().setUrl("http://localhost:9000/test"))
+            .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> {
+          notificationChannelConfigServiceRequestValidator.validateWebhookConfigExclusionDomains(
+              notificationChannelMutableDataWithExcludedDomain,
+              config.getConfig(NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG));
+        },
+        "RuntimeException was expected");
+    NotificationChannelMutableData notificationChannelMutableDataWithValidDomain =
+        NotificationChannelMutableData.newBuilder()
+            .setChannelName("testChannel")
+            .addWebhookChannelConfig(
+                WebhookChannelConfig.newBuilder().setUrl("http://testHost:9000/test"))
+            .build();
+    notificationChannelConfigServiceRequestValidator.validateWebhookConfigExclusionDomains(
+        notificationChannelMutableDataWithValidDomain,
+        config.getConfig(NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG));
+  }
+
+  @Test
+  public void testValidateWebhookHttpsSupport() {
+    NotificationChannelConfigServiceRequestValidator
+        notificationChannelConfigServiceRequestValidator =
+            new NotificationChannelConfigServiceRequestValidator();
+    File configFile = new File(ClassLoader.getSystemResource("application.conf").getPath());
+    Config config = ConfigFactory.parseFile(configFile);
+    NotificationChannelMutableData notificationChannelWithHttpUrl =
+        NotificationChannelMutableData.newBuilder()
+            .setChannelName("testChannel")
+            .addWebhookChannelConfig(
+                WebhookChannelConfig.newBuilder().setUrl("http://localhost:9000/test"))
+            .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> {
+          notificationChannelConfigServiceRequestValidator.validateWebhookHttpSupport(
+              notificationChannelWithHttpUrl,
+              config.getConfig(NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG));
+        },
+        "RuntimeException was expected");
+    NotificationChannelMutableData notificationChannelWithInvalidUrl =
+        NotificationChannelMutableData.newBuilder()
+            .setChannelName("testChannel")
+            .addWebhookChannelConfig(WebhookChannelConfig.newBuilder().setUrl("localhost"))
+            .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> {
+          notificationChannelConfigServiceRequestValidator.validateWebhookHttpSupport(
+              notificationChannelWithInvalidUrl,
+              config.getConfig(NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG));
+        },
+        "RuntimeException was expected");
+
+    NotificationChannelMutableData notificationChannelMutableDataWithHttpsUrl =
+        NotificationChannelMutableData.newBuilder()
+            .setChannelName("testChannel")
+            .addWebhookChannelConfig(
+                WebhookChannelConfig.newBuilder().setUrl("https://localhost:9000/test"))
+            .build();
+    notificationChannelConfigServiceRequestValidator.validateWebhookHttpSupport(
+        notificationChannelMutableDataWithHttpsUrl,
+        config.getConfig(NOTIFICATION_CHANNEL_CONFIG_SERVICE_CONFIG));
+  }
+}

--- a/notification-channel-config-service-impl/src/test/resources/application.conf
+++ b/notification-channel-config-service-impl/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+notification.channel.config.service {
+    webhook.exclusion.domains = ["localhost"]
+    webhook.http.support.enabled = false
+}

--- a/notification-rule-config-service-api/build.gradle.kts
+++ b/notification-rule-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/partitioner-config-service-api/build.gradle.kts
+++ b/partitioner-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/spaces-config-service-api/build.gradle.kts
+++ b/spaces-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {

--- a/span-processing-config-service-api/build.gradle.kts
+++ b/span-processing-config-service-api/build.gradle.kts
@@ -31,6 +31,11 @@ protobuf {
 
 dependencies {
   api(libs.bundles.grpc.api)
+  constraints {
+    implementation("com.google.guava:guava:32.0.1-jre") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2023-2976")
+    }
+  }
 }
 
 sourceSets {


### PR DESCRIPTION
## Description
Add domain exclusion config for notification channel config service. This config will fail the creation/update of notification channels if it contains exclusion domains.  
