### PR TITLE
Add not exists, not equals and not matches regex operator support for label application rules

### DIFF
--- a/label-application-rule-config-service-api/src/main/proto/org/hypertrace/label/application/rule/config/service/v1/label_application_rule.proto
+++ b/label-application-rule-config-service-api/src/main/proto/org/hypertrace/label/application/rule/config/service/v1/label_application_rule.proto
@@ -61,6 +61,8 @@ message LabelApplicationRuleData {
       OPERATOR_MATCHES_REGEX = 2; // operator to check if the key exists, and value matches the provided regex value
       OPERATOR_MATCHES_IPS = 3; // operator to check if the key exists, and IP value matches provided IP(s), CIDR(s)
       OPERATOR_NOT_MATCHES_IPS = 4; // operator to check if the key exists, and IP doesn't match provided IP(s), CIDR(s)
+      OPERATOR_NOT_EQUALS = 5; // operator to check if the key exists, and value is not equal to the provided value
+      OPERATOR_NOT_MATCHES_REGEX = 6; // operator to check if the key exists, and value not matches the provided regex value
     }
   }
 
@@ -70,6 +72,7 @@ message LabelApplicationRuleData {
     enum Operator {
       OPERATOR_UNSPECIFIED = 0;
       OPERATOR_EXISTS = 1; // checks for existence of the key
+      OPERATOR_NOT_EXISTS = 2; // checks for non-existence of the key
     }
   }
 

--- a/label-application-rule-config-service-impl/src/main/java/org/hypertrace/label/application/rule/config/service/LabelApplicationRuleValidatorImpl.java
+++ b/label-application-rule-config-service-impl/src/main/java/org/hypertrace/label/application/rule/config/service/LabelApplicationRuleValidatorImpl.java
@@ -151,6 +151,7 @@ public class LabelApplicationRuleValidatorImpl implements LabelApplicationRuleVa
     validateNonDefaultPresenceOrThrow(stringCondition, StringCondition.OPERATOR_FIELD_NUMBER);
     switch (stringCondition.getOperator()) {
       case OPERATOR_MATCHES_REGEX:
+      case OPERATOR_NOT_MATCHES_REGEX:
         validateNonDefaultPresenceOrThrow(stringCondition, StringCondition.VALUE_FIELD_NUMBER);
         final String pattern = stringCondition.getValue();
         final Status regexValidationStatus = RegexValidator.validate(pattern);


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
