### PR TITLE
Separate out string key and string value condition messages for label application rules

### DIFF
--- a/label-application-rule-config-service-api/src/main/proto/org/hypertrace/label/application/rule/config/service/v1/label_application_rule.proto
+++ b/label-application-rule-config-service-api/src/main/proto/org/hypertrace/label/application/rule/config/service/v1/label_application_rule.proto
@@ -36,15 +36,28 @@ message LabelApplicationRuleData {
 
   message LeafCondition {
     // only equals and regex are supported for key condition
-    StringCondition key_condition = 1;
+    StringKeyCondition key_condition = 1;
     oneof condition {
-      StringCondition string_condition = 2;
+      StringValueCondition string_condition = 2;
       UnaryCondition unary_condition = 3;
       JsonCondition json_condition = 4;
     }
   }
 
-  message StringCondition {
+  message StringKeyCondition {
+    Operator operator = 1;
+    oneof kind {
+      string value = 2;
+    }
+
+    enum Operator {
+      OPERATOR_UNSPECIFIED = 0;
+      OPERATOR_EQUALS = 1; // operator to check if the key exists, and value is equal to the provided value
+      OPERATOR_MATCHES_REGEX = 2; // operator to check if the key exists, and value matches the provided regex value
+    }
+  }
+
+  message StringValueCondition {
     Operator operator = 1;
     oneof kind {
       string value = 2;
@@ -79,7 +92,7 @@ message LabelApplicationRuleData {
   message JsonCondition {
     string json_path = 1; // path to json structure
     oneof value_condition {
-      StringCondition string_condition = 2;
+      StringValueCondition string_condition = 2;
       UnaryCondition unary_condition = 3;
     }
   }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
