### PR TITLE
Expose URL_PATH in exclusion rules

### DIFF
--- a/span-processing-config-service-api/src/main/proto/org/hypertrace/span/processing/config/service/v1/span_filter.proto
+++ b/span-processing-config-service-api/src/main/proto/org/hypertrace/span/processing/config/service/v1/span_filter.proto
@@ -47,6 +47,7 @@ enum Field {
   FIELD_URL = 1;
   FIELD_SERVICE_NAME = 2;
   FIELD_ENVIRONMENT_NAME = 3;
+  FIELD_URL_PATH = 4;
 }
 
 enum RelationalOperator {

--- a/span-processing-config-service-impl/src/test/java/org/hypertrace/span/processing/config/service/SpanProcessingConfigServiceImplTest.java
+++ b/span-processing-config-service-impl/src/test/java/org/hypertrace/span/processing/config/service/SpanProcessingConfigServiceImplTest.java
@@ -1,6 +1,7 @@
 package org.hypertrace.span.processing.config.service;
 
 import static org.hypertrace.span.processing.config.service.v1.Field.FIELD_URL;
+import static org.hypertrace.span.processing.config.service.v1.Field.FIELD_URL_PATH;
 import static org.hypertrace.span.processing.config.service.v1.LogicalOperator.LOGICAL_OPERATOR_AND;
 import static org.hypertrace.span.processing.config.service.v1.RelationalOperator.RELATIONAL_OPERATOR_CONTAINS;
 import static org.hypertrace.span.processing.config.service.v1.RuleType.RULE_TYPE_SYSTEM;
@@ -284,6 +285,18 @@ class SpanProcessingConfigServiceImplTest {
                                                         .build())
                                                 .build())
                                         .build())
+                                .addOperands(
+                                    SpanFilter.newBuilder()
+                                        .setRelationalSpanFilter(
+                                            RelationalSpanFilterExpression.newBuilder()
+                                                .setOperator(RELATIONAL_OPERATOR_CONTAINS)
+                                                .setField(FIELD_URL_PATH)
+                                                .setRightOperand(
+                                                    SpanFilterValue.newBuilder()
+                                                        .setStringValue("health")
+                                                        .build())
+                                                .build())
+                                        .build())
                                 .build())
                         .build())
                 .build())
@@ -321,6 +334,15 @@ class SpanProcessingConfigServiceImplTest {
                                             Map.of(
                                                 "field",
                                                 "FIELD_URL",
+                                                "operator",
+                                                "RELATIONAL_OPERATOR_CONTAINS",
+                                                "right_operand",
+                                                Map.of("string_value", "health"))),
+                                        Map.of(
+                                            "relational_span_filter",
+                                            Map.of(
+                                                "field",
+                                                "FIELD_URL_PATH",
                                                 "operator",
                                                 "RELATIONAL_OPERATOR_CONTAINS",
                                                 "right_operand",


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

While creating exclusion rules, having “URL path” as a first class field would be very helpful to have exclusion rules only on the “URL path”, and not query parameters/anchor tags

Say, we want to exclude static URLs (.html, .css etc). Basically, excluding URLs ending with a certain extension. The regex for exclusion rule becomes clumsy and inaccurate on “full URLs”, since it could have query parameters

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
