### PR TITLE
Changes in Notification rule to allow types

### DIFF
--- a/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
+++ b/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
@@ -30,11 +30,6 @@ message NotificationChannelTarget {
 }
 
 message NotificationIntegrationTarget {
-  IntegrationType type = 1;
+  string type = 1;
   string integration_id = 2;
-}
-
-enum IntegrationType {
-  INTEGRATION_TYPE_UNSPECIFIED = 0;
-  INTEGRATION_TYPE_WIZ = 1;
 }

--- a/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
+++ b/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
@@ -19,12 +19,22 @@ message NotificationRuleMutableData {
   string channel_id = 5 [deprecated=true];
   string rate_limit_interval_duration = 6;
 
-  string sink_id = 7;
-  SinkType sink_type = 8;
+  oneof notification_target {
+    NotificationChannelTarget channel_target = 7;
+    NotificationIntegrationTarget integration_target = 8;
+  }
 }
 
-enum SinkType {
-  SINK_TYPE_UNSPECIFIED = 0;
-  SINK_TYPE_CHANNEL = 1;
-  SINK_TYPE_WIZ_INTEGRATION = 2;
+message NotificationChannelTarget {
+  string channel_id = 1;
+}
+
+message NotificationIntegrationTarget {
+  IntegrationType type = 1;
+  string integration_id = 2;
+}
+
+enum IntegrationType {
+  INTEGRATION_TYPE_UNSPECIFIED = 0;
+  INTEGRATION_TYPE_WIZ = 1;
 }

--- a/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
+++ b/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
@@ -16,6 +16,15 @@ message NotificationRuleMutableData {
   string event_condition_id = 3;
   string event_condition_type = 4;
 
-  string channel_id = 5;
+  string channel_id = 5 [deprecated=true];
   string rate_limit_interval_duration = 6;
+
+  string sink_id = 7;
+  SinkType sink_type = 8;
+}
+
+enum SinkType {
+  SINK_TYPE_UNSPECIFIED = 0;
+  SINK_TYPE_CHANNEL = 1;
+  SINK_TYPE_WIZ_INTEGRATION = 2;
 }

--- a/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
+++ b/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
@@ -16,17 +16,10 @@ message NotificationRuleMutableData {
   string event_condition_id = 3;
   string event_condition_type = 4;
 
-  string channel_id = 5 [deprecated=true];
+  string channel_id = 5;
   string rate_limit_interval_duration = 6;
 
-  oneof notification_target {
-    NotificationChannelTarget channel_target = 7;
-    NotificationIntegrationTarget integration_target = 8;
-  }
-}
-
-message NotificationChannelTarget {
-  string channel_id = 1;
+  NotificationIntegrationTarget integration_target = 7;
 }
 
 message NotificationIntegrationTarget {

--- a/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
+++ b/notification-rule-config-service-api/src/main/proto/org/hypertrace/notification/config/service/v1/notification_rule.proto
@@ -16,7 +16,7 @@ message NotificationRuleMutableData {
   string event_condition_id = 3;
   string event_condition_type = 4;
 
-  string channel_id = 5;
+  optional string channel_id = 5;
   string rate_limit_interval_duration = 6;
 
   NotificationIntegrationTarget integration_target = 7;

--- a/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
+++ b/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
@@ -3,6 +3,7 @@ package org.hypertrace.notification.config.service;
 import static org.hypertrace.config.validation.GrpcValidatorUtils.validateNonDefaultPresenceOrThrow;
 import static org.hypertrace.config.validation.GrpcValidatorUtils.validateRequestContextOrThrow;
 
+import io.grpc.Status;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.notification.config.service.v1.CreateNotificationRuleRequest;
 import org.hypertrace.notification.config.service.v1.DeleteNotificationRuleRequest;
@@ -34,6 +35,11 @@ public class NotificationRuleConfigServiceRequestValidator {
           data.getIntegrationTarget(), NotificationIntegrationTarget.INTEGRATION_ID_FIELD_NUMBER);
       validateNonDefaultPresenceOrThrow(
           data.getIntegrationTarget(), NotificationIntegrationTarget.TYPE_FIELD_NUMBER);
+      if (data.hasChannelId()) {
+        throw Status.INVALID_ARGUMENT
+            .withDescription("Channel Id should not be populated with integration target.")
+            .asRuntimeException();
+      }
     } else {
       validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
     }

--- a/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
+++ b/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
@@ -8,7 +8,6 @@ import org.hypertrace.notification.config.service.v1.CreateNotificationRuleReque
 import org.hypertrace.notification.config.service.v1.DeleteNotificationRuleRequest;
 import org.hypertrace.notification.config.service.v1.GetAllNotificationRulesRequest;
 import org.hypertrace.notification.config.service.v1.GetNotificationRuleRequest;
-import org.hypertrace.notification.config.service.v1.NotificationChannelTarget;
 import org.hypertrace.notification.config.service.v1.NotificationIntegrationTarget;
 import org.hypertrace.notification.config.service.v1.NotificationRuleMutableData;
 import org.hypertrace.notification.config.service.v1.UpdateNotificationRuleRequest;
@@ -30,22 +29,13 @@ public class NotificationRuleConfigServiceRequestValidator {
 
   private void validateNotificationRuleMutableData(NotificationRuleMutableData data) {
     validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.RULE_NAME_FIELD_NUMBER);
-    switch (data.getNotificationTargetCase()) {
-      case CHANNEL_TARGET:
-        validateNonDefaultPresenceOrThrow(
-            data.getChannelTarget(), NotificationChannelTarget.CHANNEL_ID_FIELD_NUMBER);
-        break;
-      case INTEGRATION_TARGET:
-        validateNonDefaultPresenceOrThrow(
-            data.getIntegrationTarget(), NotificationIntegrationTarget.INTEGRATION_ID_FIELD_NUMBER);
-        validateNonDefaultPresenceOrThrow(
-            data.getIntegrationTarget(), NotificationIntegrationTarget.TYPE_FIELD_NUMBER);
-        break;
-      case NOTIFICATIONTARGET_NOT_SET:
-      default:
-        // backward compatibility
-        validateNonDefaultPresenceOrThrow(
-            data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
+    if (data.hasIntegrationTarget()) {
+      validateNonDefaultPresenceOrThrow(
+          data.getIntegrationTarget(), NotificationIntegrationTarget.INTEGRATION_ID_FIELD_NUMBER);
+      validateNonDefaultPresenceOrThrow(
+          data.getIntegrationTarget(), NotificationIntegrationTarget.TYPE_FIELD_NUMBER);
+    } else {
+      validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
     }
     validateNonDefaultPresenceOrThrow(
         data, NotificationRuleMutableData.EVENT_CONDITION_ID_FIELD_NUMBER);

--- a/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
+++ b/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
@@ -28,7 +28,13 @@ public class NotificationRuleConfigServiceRequestValidator {
 
   private void validateNotificationRuleMutableData(NotificationRuleMutableData data) {
     validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.RULE_NAME_FIELD_NUMBER);
-    validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
+    if (data.getSinkId().isEmpty()) {
+      // backward compatibility
+      validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
+    } else {
+      // if sink_id is present then the type should also be present
+      validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.SINK_TYPE_FIELD_NUMBER);
+    }
     validateNonDefaultPresenceOrThrow(
         data, NotificationRuleMutableData.EVENT_CONDITION_ID_FIELD_NUMBER);
     validateNonDefaultPresenceOrThrow(

--- a/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
+++ b/notification-rule-config-service-impl/src/main/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceRequestValidator.java
@@ -8,6 +8,8 @@ import org.hypertrace.notification.config.service.v1.CreateNotificationRuleReque
 import org.hypertrace.notification.config.service.v1.DeleteNotificationRuleRequest;
 import org.hypertrace.notification.config.service.v1.GetAllNotificationRulesRequest;
 import org.hypertrace.notification.config.service.v1.GetNotificationRuleRequest;
+import org.hypertrace.notification.config.service.v1.NotificationChannelTarget;
+import org.hypertrace.notification.config.service.v1.NotificationIntegrationTarget;
 import org.hypertrace.notification.config.service.v1.NotificationRuleMutableData;
 import org.hypertrace.notification.config.service.v1.UpdateNotificationRuleRequest;
 
@@ -28,12 +30,22 @@ public class NotificationRuleConfigServiceRequestValidator {
 
   private void validateNotificationRuleMutableData(NotificationRuleMutableData data) {
     validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.RULE_NAME_FIELD_NUMBER);
-    if (data.getSinkId().isEmpty()) {
-      // backward compatibility
-      validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
-    } else {
-      // if sink_id is present then the type should also be present
-      validateNonDefaultPresenceOrThrow(data, NotificationRuleMutableData.SINK_TYPE_FIELD_NUMBER);
+    switch (data.getNotificationTargetCase()) {
+      case CHANNEL_TARGET:
+        validateNonDefaultPresenceOrThrow(
+            data.getChannelTarget(), NotificationChannelTarget.CHANNEL_ID_FIELD_NUMBER);
+        break;
+      case INTEGRATION_TARGET:
+        validateNonDefaultPresenceOrThrow(
+            data.getIntegrationTarget(), NotificationIntegrationTarget.INTEGRATION_ID_FIELD_NUMBER);
+        validateNonDefaultPresenceOrThrow(
+            data.getIntegrationTarget(), NotificationIntegrationTarget.TYPE_FIELD_NUMBER);
+        break;
+      case NOTIFICATIONTARGET_NOT_SET:
+      default:
+        // backward compatibility
+        validateNonDefaultPresenceOrThrow(
+            data, NotificationRuleMutableData.CHANNEL_ID_FIELD_NUMBER);
     }
     validateNonDefaultPresenceOrThrow(
         data, NotificationRuleMutableData.EVENT_CONDITION_ID_FIELD_NUMBER);

--- a/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
+++ b/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
@@ -10,7 +10,6 @@ import org.hypertrace.notification.config.service.v1.CreateNotificationRuleReque
 import org.hypertrace.notification.config.service.v1.DeleteNotificationRuleRequest;
 import org.hypertrace.notification.config.service.v1.GetAllNotificationRulesRequest;
 import org.hypertrace.notification.config.service.v1.GetNotificationRuleRequest;
-import org.hypertrace.notification.config.service.v1.NotificationChannelTarget;
 import org.hypertrace.notification.config.service.v1.NotificationRule;
 import org.hypertrace.notification.config.service.v1.NotificationRuleConfigServiceGrpc;
 import org.hypertrace.notification.config.service.v1.NotificationRuleMutableData;
@@ -46,14 +45,11 @@ class NotificationRuleConfigServiceImplTest {
     NotificationRuleMutableData notificationRuleMutableData2 =
         getNotificationRuleMutableData("rule2", "channel1");
 
-    // should return a compatible rule with notification target populated
-    NotificationRuleMutableData oldNotificationRuleMutableData =
-        notificationRuleMutableData1.toBuilder().clearChannelTarget().build();
     NotificationRule notificationRule1 =
         notificationStub
             .createNotificationRule(
                 CreateNotificationRuleRequest.newBuilder()
-                    .setNotificationRuleMutableData(oldNotificationRuleMutableData)
+                    .setNotificationRuleMutableData(notificationRuleMutableData1)
                     .build())
             .getNotificationRule();
     assertEquals(
@@ -132,7 +128,6 @@ class NotificationRuleConfigServiceImplTest {
         .setChannelId(channelId)
         .setEventConditionType("metricAnomalyEventCondition")
         .setEventConditionId("rule-1")
-        .setChannelTarget(NotificationChannelTarget.newBuilder().setChannelId(channelId))
         .build();
   }
 

--- a/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
+++ b/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
@@ -10,6 +10,7 @@ import org.hypertrace.notification.config.service.v1.CreateNotificationRuleReque
 import org.hypertrace.notification.config.service.v1.DeleteNotificationRuleRequest;
 import org.hypertrace.notification.config.service.v1.GetAllNotificationRulesRequest;
 import org.hypertrace.notification.config.service.v1.GetNotificationRuleRequest;
+import org.hypertrace.notification.config.service.v1.NotificationChannelTarget;
 import org.hypertrace.notification.config.service.v1.NotificationRule;
 import org.hypertrace.notification.config.service.v1.NotificationRuleConfigServiceGrpc;
 import org.hypertrace.notification.config.service.v1.NotificationRuleMutableData;
@@ -44,11 +45,15 @@ class NotificationRuleConfigServiceImplTest {
         getNotificationRuleMutableData("rule1", "channel1");
     NotificationRuleMutableData notificationRuleMutableData2 =
         getNotificationRuleMutableData("rule2", "channel1");
+
+    // should return a compatible rule with notification target populated
+    NotificationRuleMutableData oldNotificationRuleMutableData = notificationRuleMutableData1
+            .toBuilder().clearChannelTarget().build();
     NotificationRule notificationRule1 =
         notificationStub
             .createNotificationRule(
                 CreateNotificationRuleRequest.newBuilder()
-                    .setNotificationRuleMutableData(notificationRuleMutableData1)
+                    .setNotificationRuleMutableData(oldNotificationRuleMutableData)
                     .build())
             .getNotificationRule();
     assertEquals(
@@ -127,6 +132,7 @@ class NotificationRuleConfigServiceImplTest {
         .setChannelId(channelId)
         .setEventConditionType("metricAnomalyEventCondition")
         .setEventConditionId("rule-1")
+        .setChannelTarget(NotificationChannelTarget.newBuilder().setChannelId(channelId))
         .build();
   }
 

--- a/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
+++ b/notification-rule-config-service-impl/src/test/java/org/hypertrace/notification/config/service/NotificationRuleConfigServiceImplTest.java
@@ -47,8 +47,8 @@ class NotificationRuleConfigServiceImplTest {
         getNotificationRuleMutableData("rule2", "channel1");
 
     // should return a compatible rule with notification target populated
-    NotificationRuleMutableData oldNotificationRuleMutableData = notificationRuleMutableData1
-            .toBuilder().clearChannelTarget().build();
+    NotificationRuleMutableData oldNotificationRuleMutableData =
+        notificationRuleMutableData1.toBuilder().clearChannelTarget().build();
     NotificationRule notificationRule1 =
         notificationStub
             .createNotificationRule(


### PR DESCRIPTION
## Description
For non-streaming notification. Particularly for integrations supporting a batched type of notification.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
