### PR TITLE
Revert "chore | Proto changes for adding evaluation targets for each exclude span rule"

### DIFF
--- a/span-processing-config-service-api/src/main/proto/org/hypertrace/span/processing/config/service/v1/span_processing_config_service.proto
+++ b/span-processing-config-service-api/src/main/proto/org/hypertrace/span/processing/config/service/v1/span_processing_config_service.proto
@@ -66,22 +66,7 @@ message ExcludeSpanRuleInfo {
   SpanFilter filter = 2;
   bool disabled = 3;
   RuleType type = 4;
-  repeated EvaluationTarget evaluation_targets = 5;
 }
-
-message EvaluationTarget {
-  oneof target {
-    Platform platform = 1;
-    Agent agent = 2;
-    AgentModule agent_module = 3;
-  }
-}
-
-message Platform {}
-
-message Agent {}
-
-message AgentModule {}
 
 message ExcludeSpanRuleMetadata {
   google.protobuf.Timestamp creation_timestamp = 1;


### PR DESCRIPTION
Reverts hypertrace/config-service#216