### PR TITLE
Add email in config_change_event_value.proto

### DIFF
--- a/config-service-change-event-api/src/main/proto/org/hypertrace/config/change/event/v1/config_change_event_value.proto
+++ b/config-service-change-event-api/src/main/proto/org/hypertrace/config/change/event/v1/config_change_event_value.proto
@@ -15,7 +15,6 @@ message ConfigChangeEventValue {
   optional string user_id = 4;
   optional string user_name = 5;
   string user_email = 7;
-
   int64 event_time_millis = 6;
 }
 

--- a/config-service-change-event-api/src/main/proto/org/hypertrace/config/change/event/v1/config_change_event_value.proto
+++ b/config-service-change-event-api/src/main/proto/org/hypertrace/config/change/event/v1/config_change_event_value.proto
@@ -14,6 +14,7 @@ message ConfigChangeEventValue {
   }
   optional string user_id = 4;
   optional string user_name = 5;
+  optional string user_email = 7;
   int64 event_time_millis = 6;
 }
 

--- a/config-service-change-event-generator/src/main/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImpl.java
+++ b/config-service-change-event-generator/src/main/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImpl.java
@@ -178,6 +178,7 @@ public class ConfigChangeEventGeneratorImpl implements ConfigChangeEventGenerato
 
   private void populateUserDetails(RequestContext requestContext, Builder builder) {
     requestContext.getUserId().ifPresent(builder::setUserId);
-    requestContext.getName().or(requestContext::getEmail).ifPresent(builder::setUserName);
+    requestContext.getName().ifPresent(builder::setUserName);
+    requestContext.getEmail().ifPresent(builder::setUserEmail);
   }
 }

--- a/config-service-change-event-generator/src/test/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImplTest.java
+++ b/config-service-change-event-generator/src/test/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImplTest.java
@@ -53,7 +53,25 @@ class ConfigChangeEventGeneratorImplTest {
   }
 
   @Test
-  void sendCreateNotificationWithUserDetailsInContext() throws InvalidProtocolBufferException {
+  void sendCreateNotification() throws InvalidProtocolBufferException {
+    Value config = createStringValue();
+    changeEventGenerator.sendCreateNotification(
+        requestContext, TEST_CONFIG_TYPE, TEST_CONTEXT, config);
+    verify(eventProducer)
+        .send(
+            KeyUtil.getKey(TEST_TENANT_ID_1, TEST_CONFIG_TYPE, Optional.of(TEST_CONTEXT)),
+            ConfigChangeEventValue.newBuilder()
+                .setEventTimeMillis(CURRENT_TIME_MILLIS)
+                .setCreateEvent(
+                    ConfigCreateEvent.newBuilder()
+                        .setCreatedConfigJson(ConfigProtoConverter.convertToJsonString(config))
+                        .build())
+                .build());
+  }
+
+  @Test
+  void sendCreateNotificationWithUserDetailsInRequestContext()
+      throws InvalidProtocolBufferException {
     Value config = createStringValue();
     when(requestContext.getUserId()).thenReturn(Optional.of(TEST_USER_ID));
     when(requestContext.getName()).thenReturn(Optional.of(TEST_USER_NAME));
@@ -67,23 +85,6 @@ class ConfigChangeEventGeneratorImplTest {
                 .setUserId(TEST_USER_ID)
                 .setUserEmail(TEST_USER_EMAIL)
                 .setUserName(TEST_USER_NAME)
-                .setEventTimeMillis(CURRENT_TIME_MILLIS)
-                .setCreateEvent(
-                    ConfigCreateEvent.newBuilder()
-                        .setCreatedConfigJson(ConfigProtoConverter.convertToJsonString(config))
-                        .build())
-                .build());
-  }
-
-  @Test
-  void sendCreateNotification() throws InvalidProtocolBufferException {
-    Value config = createStringValue();
-    changeEventGenerator.sendCreateNotification(
-        requestContext, TEST_CONFIG_TYPE, TEST_CONTEXT, config);
-    verify(eventProducer)
-        .send(
-            KeyUtil.getKey(TEST_TENANT_ID_1, TEST_CONFIG_TYPE, Optional.of(TEST_CONTEXT)),
-            ConfigChangeEventValue.newBuilder()
                 .setEventTimeMillis(CURRENT_TIME_MILLIS)
                 .setCreateEvent(
                     ConfigCreateEvent.newBuilder()

--- a/config-service-change-event-generator/src/test/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImplTest.java
+++ b/config-service-change-event-generator/src/test/java/org/hypertrace/config/service/change/event/impl/ConfigChangeEventGeneratorImplTest.java
@@ -32,6 +32,9 @@ class ConfigChangeEventGeneratorImplTest {
   private static final String TEST_CONTEXT = "test-context";
   private static final String TEST_VALUE = "test-value";
   private static final String TEST_NEW_VALUE = "test-new-value";
+  private static final String TEST_USER_ID = "test-user-id";
+  private static final String TEST_USER_NAME = "test-user-name";
+  private static final String TEST_USER_EMAIL = "test-user-email";
   private static final long CURRENT_TIME_MILLIS = 1000;
 
   @Mock EventProducer<ConfigChangeEventKey, ConfigChangeEventValue> eventProducer;
@@ -45,7 +48,31 @@ class ConfigChangeEventGeneratorImplTest {
     mockClock = mock(Clock.class);
     when(mockClock.millis()).thenReturn(CURRENT_TIME_MILLIS);
     changeEventGenerator = new ConfigChangeEventGeneratorImpl(eventProducer, mockClock);
-    requestContext = RequestContext.forTenantId(TEST_TENANT_ID_1);
+    requestContext = mock(RequestContext.class);
+    when(requestContext.getTenantId()).thenReturn(Optional.of(TEST_TENANT_ID_1));
+  }
+
+  @Test
+  void sendCreateNotificationWithUserDetailsInContext() throws InvalidProtocolBufferException {
+    Value config = createStringValue();
+    when(requestContext.getUserId()).thenReturn(Optional.of(TEST_USER_ID));
+    when(requestContext.getName()).thenReturn(Optional.of(TEST_USER_NAME));
+    when(requestContext.getEmail()).thenReturn(Optional.of(TEST_USER_EMAIL));
+    changeEventGenerator.sendCreateNotification(
+        requestContext, TEST_CONFIG_TYPE, TEST_CONTEXT, config);
+    verify(eventProducer)
+        .send(
+            KeyUtil.getKey(TEST_TENANT_ID_1, TEST_CONFIG_TYPE, Optional.of(TEST_CONTEXT)),
+            ConfigChangeEventValue.newBuilder()
+                .setUserId(TEST_USER_ID)
+                .setUserEmail(TEST_USER_EMAIL)
+                .setUserName(TEST_USER_NAME)
+                .setEventTimeMillis(CURRENT_TIME_MILLIS)
+                .setCreateEvent(
+                    ConfigCreateEvent.newBuilder()
+                        .setCreatedConfigJson(ConfigProtoConverter.convertToJsonString(config))
+                        .build())
+                .build());
   }
 
   @Test


### PR DESCRIPTION
Capture user email when generating change events. This is required to filter out the names of traceable employees on customers' activity logs.