### PR TITLE
made adding public of upsert function in identified object store

### DIFF
--- a/config-object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
+++ b/config-object-store/src/main/java/org/hypertrace/config/objectstore/IdentifiedObjectStore.java
@@ -154,7 +154,7 @@ public abstract class IdentifiedObjectStore<T> {
     return getObject(context, id).map(ConfigObject::getData);
   }
 
-  private ContextualConfigObject<T> upsertObject(
+  protected ContextualConfigObject<T> upsertObject(
       RequestContext context, UpsertConfigRequest request) {
     UpsertConfigResponse response =
         context.call(
@@ -281,7 +281,7 @@ public abstract class IdentifiedObjectStore<T> {
     return optionalResult;
   }
 
-  private Optional<ContextualConfigObject<T>> processUpsertResult(
+  protected Optional<ContextualConfigObject<T>> processUpsertResult(
       RequestContext requestContext, UpsertedConfig upsertedConfig) {
     Optional<ContextualConfigObject<T>> optionalResult =
         ContextualConfigObjectImpl.tryBuild(upsertedConfig, this::buildDataFromValue);


### PR DESCRIPTION
## Description
Need to override the upsert function in IdentifiedObjectStore, so needs modified access specifier

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
